### PR TITLE
Run CloudFormation linter on pull request

### DIFF
--- a/.github/workflows/cloudformation-lint.yaml
+++ b/.github/workflows/cloudformation-lint.yaml
@@ -1,0 +1,22 @@
+name: CloudFormation Linter
+
+on: pull_request
+
+jobs:
+  lint:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: '3.x'
+
+      - name: Install cfn-lint
+        run: python -m pip install cfn-lint
+
+      - name: Run linter
+        run: cfn-lint infrastructure/**/template.yaml


### PR DESCRIPTION
Run `cfn-lint`[[1]] on all `template.yaml` files in the `infrastructure`
folder when a pull request is opened, re-opened or updated.

This isn't the most useful now, but it will be more useful once we start 
properly working on the prototype.

[1]: https://github.com/aws-cloudformation/cfn-lint