### PR TITLE
Create a DocumentDB backing service and pass credentials to the pods

### DIFF
--- a/infrastructure/kubernetes-demo/README.md
+++ b/infrastructure/kubernetes-demo/README.md
@@ -5,7 +5,8 @@ Deploy a Hello World Node app to an AWS EKS cluster using Fargate compute.
 ## Setup
 
 0. Make sure the common VPC and subnet stack in `infrastructure/common` has been deployed.
-1. From this folder run `sam deploy`. This will create the EKS cluster and roles and profiles with the required permissions
+1. From this folder run `sam deploy`. This will create the EKS cluster and roles and profiles with the required permissions. Save the outputs for the database endpoint and port as these will be needed later.
 2. Follow the instructions from AWS to [create a kubeconfig for EKS](https://docs.aws.amazon.com/eks/latest/userguide/create-kubeconfig.html)
 3. Follow the instructions from AWS to [set up the AWS Load Balancer Controller](https://docs.aws.amazon.com/eks/latest/userguide/aws-load-balancer-controller.html)
-4. Deploy the demo app by running `kubectl apply -f hello-world.yaml`
+4. Create a Kubernetes secret for the database endpoint and port from step 1 by running `kubectl create secret generic hello-world-db --from-literal=endpoint='ENDPOINT' --from-literal=port='PORT' -n hello-world`.
+5. Deploy the demo app by running `kubectl apply -f hello-world.yaml`

--- a/infrastructure/kubernetes-demo/hello-world.yaml
+++ b/infrastructure/kubernetes-demo/hello-world.yaml
@@ -31,6 +31,17 @@ spec:
         - name: http
           containerPort: 3000
         imagePullPolicy: IfNotPresent
+        env:
+        - name: DB_ENDPOINT
+          valueFrom:
+            secretKeyRef:
+              name: hello-world-db
+              key: endpoint
+        - name: DB_PORT
+          valueFrom:
+            secretKeyRef:
+              name: hello-world-db
+              key: port
       nodeSelector:
         kubernetes.io/os: linux
 ---

--- a/infrastructure/kubernetes-demo/template.yaml
+++ b/infrastructure/kubernetes-demo/template.yaml
@@ -268,13 +268,24 @@ Resources:
           - elasticloadbalancing:ModifyRule
           Resource: "*"
 
+  HelloWorldDocumentDBCredentials:
+    Type: 'AWS::SecretsManager::Secret'
+    Properties:
+      Name: hello-world-document-db-credentials
+      Description: "Admin credentials for the Hello World DocumentDB cluster."
+      GenerateSecretString:
+        SecretStringTemplate: '{"username": "helloworld"}'
+        GenerateStringKey: "password"
+        PasswordLength: 30
+        ExcludeCharacters: '"@/\'
+
   HelloWorldDocumentDBCluster:
     Type: AWS::DocDB::DBCluster
     DeletionPolicy: Delete
     Properties:
       DBClusterIdentifier: !Join ['', [!Ref ServiceName, DocumentDBCluster]]
-      MasterUsername: "{{resolve:secretsmanager:hello-world-doc-db-credentials:SecretString:admin-user}}"
-      MasterUserPassword: "{{resolve:secretsmanager:hello-world-doc-db-credentials:SecretString:admin-password}}"
+      MasterUsername: "{{resolve:secretsmanager:hello-world-document-db-credentials:SecretString:username}}"
+      MasterUserPassword: "{{resolve:secretsmanager:hello-world-document-db-credentials:SecretString:password}}"
       EngineVersion: 4.0.0
       AvailabilityZones:
         - !Select
@@ -284,6 +295,8 @@ Resources:
           - 1
           - Fn::GetAZs: !Ref 'AWS::Region'
       DBSubnetGroupName: !Ref HelloWorldDocumentDBSubnetGroup
+    DependsOn:
+      - HelloWorldDocumentDBCredentials
 
   HelloWorldDocumentDBInstance:
     Type: "AWS::DocDB::DBInstance"

--- a/infrastructure/kubernetes-demo/template.yaml
+++ b/infrastructure/kubernetes-demo/template.yaml
@@ -36,7 +36,7 @@ Resources:
     Type: AWS::EKS::FargateProfile
     Properties:
       ClusterName: !Ref HelloWorldEKSCluster
-      PodExecutionRoleArn: !GetAtt PodExecutionRole.Arn
+      PodExecutionRoleArn: !GetAtt HelloWorldPodExecutionRole.Arn
       Selectors:
         - Namespace: !Ref Namespace
       Subnets:
@@ -49,7 +49,7 @@ Resources:
     Type: AWS::EKS::FargateProfile
     Properties:
       ClusterName: !Ref HelloWorldEKSCluster
-      PodExecutionRoleArn: !GetAtt PodExecutionRole.Arn
+      PodExecutionRoleArn: !GetAtt KubeSystemPodExecutionRole.Arn
       Selectors:
         - Namespace: kube-system
       Subnets:
@@ -58,10 +58,24 @@ Resources:
         - Fn::ImportValue:
             Fn::Sub: "${CommonStackName}-PrivateSubnet2ID"
 
-  PodExecutionRole:
+  HelloWorldPodExecutionRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: !Join ['', [!Ref ServiceName, PodExecutionRole]]
+      RoleName: !Join ['', [!Ref ServiceName, HelloWorldPodExecutionRole]]
+      AssumeRolePolicyDocument:
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: eks-fargate-pods.amazonaws.com
+            Action: 'sts:AssumeRole'
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/AmazonEKSFargatePodExecutionRolePolicy
+        - !Ref HelloWorldPodExecutionPolicy
+
+  KubeSystemPodExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Join ['', [!Ref ServiceName, KubeSystemPodExecutionRole]]
       AssumeRolePolicyDocument:
         Statement:
           - Effect: Allow
@@ -83,6 +97,17 @@ Resources:
             Action: 'sts:AssumeRole'
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/AmazonEKSClusterPolicy
+
+  HelloWorldPodExecutionPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Effect: Allow
+          Action:
+          - secretsmanager:GetSecretValue
+          Resource: "*"
 
   AWSLoadBalancerControllerIAMPolicy:
     Type: AWS::IAM::ManagedPolicy

--- a/infrastructure/kubernetes-demo/template.yaml
+++ b/infrastructure/kubernetes-demo/template.yaml
@@ -242,3 +242,46 @@ Resources:
           - elasticloadbalancing:RemoveListenerCertificates
           - elasticloadbalancing:ModifyRule
           Resource: "*"
+
+  HelloWorldDocumentDBCluster:
+    Type: AWS::DocDB::DBCluster
+    DeletionPolicy: Delete
+    Properties:
+      DBClusterIdentifier: !Join ['', [!Ref ServiceName, DocumentDBCluster]]
+      MasterUsername: "{{resolve:secretsmanager:hello-world-doc-db-credentials:SecretString:admin-user}}"
+      MasterUserPassword: "{{resolve:secretsmanager:hello-world-doc-db-credentials:SecretString:admin-password}}"
+      EngineVersion: 4.0.0
+      AvailabilityZones:
+        - !Select
+          - 0
+          - Fn::GetAZs: !Ref 'AWS::Region'
+        - !Select
+          - 1
+          - Fn::GetAZs: !Ref 'AWS::Region'
+      DBSubnetGroupName: !Ref HelloWorldDocumentDBSubnetGroup
+
+  HelloWorldDocumentDBInstance:
+    Type: "AWS::DocDB::DBInstance"
+    Properties:
+      DBClusterIdentifier: !Ref HelloWorldDocumentDBCluster
+      DBInstanceIdentifier: !Join ['', [!Ref ServiceName, DocumentDBInstance]]
+      DBInstanceClass: db.t4g.medium
+
+  HelloWorldDocumentDBSubnetGroup:
+    Type: AWS::DocDB::DBSubnetGroup
+    Properties: 
+      DBSubnetGroupName: !Join ['', [!Ref ServiceName, DocumentDBSubnetGroup]]
+      DBSubnetGroupDescription: !Join [' ', ["Subnet group for the", !Ref ServiceName, "DocumentDB"]]
+      SubnetIds: 
+        - Fn::ImportValue:
+            Fn::Sub: "${CommonStackName}-PrivateSubnet1ID"
+        - Fn::ImportValue:
+            Fn::Sub: "${CommonStackName}-PrivateSubnet2ID"
+
+Outputs:
+  DocumentDBClusterId:
+    Value: !Ref HelloWorldDocumentDBCluster
+  DocumentDBClusterEndpoint:
+    Value: !GetAtt HelloWorldDocumentDBCluster.Endpoint
+  DocumentDBClusterPort:
+    Value: !GetAtt HelloWorldDocumentDBCluster.Port


### PR DESCRIPTION
This PR creates a DocumentDB backing service in CloudFormation, stores the username and password as secrets in AWS Secrets Manager, grants the Hello World pods access to read that secret and passes the database details to the pods as environment variables.

This is preparatory work before modifying the Node app to connect to the database and read / write data to it. 

Each commit has more details on the individual changes.

---
[Trello](https://trello.com/c/COBq3ILM/1362-create-a-mongodb-backing-service-that-speaks-to-the-eks-cluster)