### PR TITLE
Use a domain for the fargate demo service 

### DIFF
--- a/infrastructure/fargate-demo/template.yaml
+++ b/infrastructure/fargate-demo/template.yaml
@@ -10,9 +10,6 @@ Parameters:
   ContainerPort:
     Type: Number
     Default: 3000
-  LoadBalancerPort:
-    Type: Number
-    Default: 80
   CommonStackName:
     Type: String
     Default: common
@@ -145,8 +142,8 @@ Resources:
           Fn::Sub: "${CommonStackName}-VPCID"
       SecurityGroupIngress:
         - IpProtocol: tcp
-          FromPort: !Ref LoadBalancerPort
-          ToPort: !Ref LoadBalancerPort
+          FromPort: 80
+          ToPort: 80
           CidrIp: 0.0.0.0/0
         - IpProtocol: tcp
           FromPort: 443
@@ -170,10 +167,16 @@ Resources:
     Type: AWS::ElasticLoadBalancingV2::Listener
     Properties:
       DefaultActions:
-        - TargetGroupArn: !Ref HelloWorldTargetGroup
-          Type: forward
+        - Type: "redirect"
+          RedirectConfig:
+            Protocol: "HTTPS"
+            Port: 443
+            Host: "#{host}"
+            Path: "/#{path}"
+            Query: "#{query}"
+            StatusCode: "HTTP_301"
       LoadBalancerArn: !Ref LoadBalancer
-      Port: !Ref LoadBalancerPort
+      Port: 80
       Protocol: HTTP
 
   HTTPSLoadBalancerListener:
@@ -210,7 +213,3 @@ Resources:
           Fn::Sub: "${CommonStackName}-SolidRoute53"
       Type: CNAME
       TTL: 3000
-
-Outputs:
-  ServiceAddress:
-    Value: !GetAtt LoadBalancer.DNSName

--- a/infrastructure/fargate-demo/template.yaml
+++ b/infrastructure/fargate-demo/template.yaml
@@ -148,6 +148,10 @@ Resources:
           FromPort: !Ref LoadBalancerPort
           ToPort: !Ref LoadBalancerPort
           CidrIp: 0.0.0.0/0
+        - IpProtocol: tcp
+          FromPort: 443
+          ToPort: 443
+          CidrIp: 0.0.0.0/0
 
   LoadBalancer:
     Type: AWS::ElasticLoadBalancingV2::LoadBalancer
@@ -171,6 +175,41 @@ Resources:
       LoadBalancerArn: !Ref LoadBalancer
       Port: !Ref LoadBalancerPort
       Protocol: HTTP
+
+  HTTPSLoadBalancerListener:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    Properties:
+      DefaultActions:
+        - TargetGroupArn: !Ref HelloWorldTargetGroup
+          Type: forward
+      LoadBalancerArn: !Ref LoadBalancer
+      Port: 443
+      Protocol: HTTPS
+      Certificates:
+      - CertificateArn: !Ref HTTPSCertificate
+      
+  HTTPSCertificate:
+    Type: AWS::CertificateManager::Certificate
+    Properties:
+      DomainName: fargate-demo.solid.integration.account.gov.uk
+      DomainValidationOptions: 
+        - DomainName: fargate-demo.solid.integration.account.gov.uk
+          HostedZoneId: 
+            Fn::ImportValue:
+              Fn::Sub: "${CommonStackName}-SolidRoute53"
+      ValidationMethod: DNS
+
+  DNSRecord:
+    Type: AWS::Route53::RecordSet
+    Properties:
+      Name: fargate-demo.solid.integration.account.gov.uk
+      ResourceRecords:
+        - !GetAtt LoadBalancer.DNSName
+      HostedZoneId: 
+        Fn::ImportValue:
+          Fn::Sub: "${CommonStackName}-SolidRoute53"
+      Type: CNAME
+      TTL: 3000
 
 Outputs:
   ServiceAddress:


### PR DESCRIPTION
Use the delegated DNS added in [[1]] to create a DNS record, certificate
and load balancer rules to serve the fargate demo service on a
subdomain over HTTPS.

It's now available on https://fargate-demo.solid.integration.account.gov.uk/

This follows the example at [[2]] to redirect HTTP traffic to the same
URL on HTTPS.

Also remove the load balancer DNS name from the outputs since the
service is now available at a human-friendly URL.

[1]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticloadbalancingv2-listener-redirectconfig.html
[2]: https://github.com/alphagov/di-solid-prototype/pull/9

---
[JIRA](https://govukverify.atlassian.net/jira/software/c/projects/GUA/boards/195?modal=detail&selectedIssue=GUA-137)