### PR TITLE
Allow Kafka topics to be auto created

### DIFF
--- a/infrastructure/ess/template.yaml
+++ b/infrastructure/ess/template.yaml
@@ -183,7 +183,17 @@ Resources:
               Fn::Sub: "${CommonStackName}-PrivateSubnet1ID"
           - Fn::ImportValue:
               Fn::Sub: "${CommonStackName}-PrivateSubnet2ID"
-
+      ConfigurationInfo:
+        Revision: 1
+        Arn: !Ref MSKConfiguration
+    
+  MSKConfiguration:
+    Type: AWS::MSK::Configuration
+    Properties:
+      Name: ESS-MSK-cluster-configuration
+      ServerProperties: |
+        auto.create.topics.enable=true
+  
   MSKSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:


### PR DESCRIPTION
We are seeing error logs that Kafka topics don't exist. Update the
cluster configuration to allow it to auto-create topics if needed.