### PR TITLE
Fix aurora

### DIFF
--- a/infrastructure/ess/template.yaml
+++ b/infrastructure/ess/template.yaml
@@ -270,8 +270,8 @@ Resources:
           Fn::Sub: "${CommonStackName}-VPCID"
       SecurityGroupIngress:
       - IpProtocol: tcp
-        FromPort: 5432
-        ToPort: 5432
+        FromPort: 3306
+        ToPort: 3306
         CidrIp: 10.0.0.0/16
 
   EssMSK:


### PR DESCRIPTION
Inrupts fragments-ingest and fragments-query pods seem to be erroring
pretty hard. We've traced an error in the logs that seems to be with it
trying to bootstrap a Postgres Aurora serverless v10.7 instance using
`PROCEDURE`.

After some sluthing, turns out that's a feature of v11 onwards:

`PROCEDURE` https://www.postgresql.org/docs/11/sql-createprocedure.html

Alas, here the fun begins, we'd chosen Aurora serverless because it's a
better fit with the overall DI Tech streategy... Aurora v2 serverless is
now available in the London zone and supports up to postgrest v13.7...

So why are we not using it? Turns out CloudFormation does not currently
support v2 serverless Aurora https://github.com/aws/aws-cdk/issues/20197

So for the sake of expdiency (this is a POC after all), we're gonna
switch these back to provisioned, dump the scaling parameters and then
bump up to a version that supports PROCEDURE