### PR TITLE
GUA-220: Deploy the prototype app

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,15 @@ A prototype to evaluate Solid as a personal data store
 2. Run `npm run build` to build the app
 3. Run `npm start` to start the local server
 4. Visit `http://localhost:3000` in your browser 
+
+## Deployment
+
+The app is deployed to AWS ECS on Fargate and is available at https://prototype.solid.integration.account.gov.uk/
+
+To deploy a new version:
+```bash
+cd infastructure/prototype-app
+gds aws di-solid-prototype ./deploy.sh
+```
+
+This will build a new Docker image, tag it with the Git hash, upload that image to ECR and finally deploy the app.

--- a/infrastructure/prototype-app/build_and_push_image.sh
+++ b/infrastructure/prototype-app/build_and_push_image.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -euxo pipefail
+
+tag=$(git rev-parse --short HEAD)
+
+ecr_registry=626456592666.dkr.ecr.eu-west-2.amazonaws.com
+ecr_repository=solid-prototype-app
+
+docker build -t $ecr_registry/$ecr_repository:$tag ../../
+aws ecr get-login-password --region eu-west-2 | docker login --username AWS --password-stdin $ecr_registry
+docker push $ecr_registry/$ecr_repository:$tag

--- a/infrastructure/prototype-app/deploy.sh
+++ b/infrastructure/prototype-app/deploy.sh
@@ -9,3 +9,4 @@ ecr_repository=solid-prototype-app
 docker build -t $ecr_registry/$ecr_repository:$tag ../../
 aws ecr get-login-password --region eu-west-2 | docker login --username AWS --password-stdin $ecr_registry
 docker push $ecr_registry/$ecr_repository:$tag
+sam deploy --parameter-overrides ParameterKey=ImageTag,ParameterValue=$tag --confirm-changeset

--- a/infrastructure/prototype-app/samconfig.toml
+++ b/infrastructure/prototype-app/samconfig.toml
@@ -5,5 +5,5 @@ version = 0.1
 stack_name = "prototype-app"
 region = "eu-west-2"
 confirm_changeset = true
-capabilities = "CAPABILITY_IAM"
+capabilities = "CAPABILITY_NAMED_IAM"
 image_repositories = []

--- a/infrastructure/prototype-app/samconfig.toml
+++ b/infrastructure/prototype-app/samconfig.toml
@@ -1,0 +1,9 @@
+version = 0.1
+[default]
+[default.deploy]
+[default.deploy.parameters]
+stack_name = "prototype-app"
+region = "eu-west-2"
+confirm_changeset = true
+capabilities = "CAPABILITY_IAM"
+image_repositories = []

--- a/infrastructure/prototype-app/template.yaml
+++ b/infrastructure/prototype-app/template.yaml
@@ -3,12 +3,224 @@ Transform: AWS::Serverless-2016-10-31
 
 Description: "Deploy the Solid proof of concept app"
 
+Parameters:
+  ContainerPort:
+    Type: Number
+    Default: 3000
+  CommonStackName:
+    Type: String
+    Default: common
+  ImageTag:
+    Type: String
+    Default: 9615586
+
 Resources:
   ContainerRepository:
     Type: AWS::ECR::Repository
     Properties: 
       ImageTagMutability: IMMUTABLE
       RepositoryName: solid-prototype-app
+
+  ECSCluster:
+    Type: AWS::ECS::Cluster
+    Properties:
+      CapacityProviders: [
+        "FARGATE_SPOT"
+      ]
+
+  TaskDefinition:
+    Type: AWS::ECS::TaskDefinition
+    Properties:
+      NetworkMode: awsvpc
+      Cpu: '256'
+      Memory: '512'
+      RequiresCompatibilities:
+        - FARGATE
+      TaskRoleArn: !GetAtt TaskRole.Arn
+      ExecutionRoleArn: !GetAtt ExecutionRole.Arn
+      ContainerDefinitions:
+        - Name: solid-prototype-app
+          Cpu: '256'
+          Memory: '512'
+          Image: !Join ['', [!GetAtt ContainerRepository.RepositoryUri, ':', !Ref ImageTag]]
+          PortMappings:
+            - ContainerPort: !Ref ContainerPort
+
+  Service:
+    Type: AWS::ECS::Service
+    DependsOn: LoadBalancerRule
+    Properties:
+      ServiceName: solid-prototype-app
+      Cluster: !GetAtt ECSCluster.Arn
+      LaunchType: FARGATE
+      DeploymentConfiguration:
+        MaximumPercent: 200
+        MinimumHealthyPercent: 100
+      DesiredCount: 1
+      HealthCheckGracePeriodSeconds: 15
+      NetworkConfiguration:
+        AwsvpcConfiguration:
+          AssignPublicIp: ENABLED
+          SecurityGroups:
+            - !Ref ContainerSecurityGroup
+          Subnets:
+            - Fn::ImportValue:
+                Fn::Sub: "${CommonStackName}-PublicSubnet1ID"
+            - Fn::ImportValue:
+                Fn::Sub: "${CommonStackName}-PublicSubnet2ID"
+      TaskDefinition: !Ref TaskDefinition
+      LoadBalancers:
+        - ContainerName: solid-prototype-app
+          ContainerPort: !Ref ContainerPort
+          TargetGroupArn: !Ref TargetGroup
+
+  TargetGroup:
+    Type: AWS::ElasticLoadBalancingV2::TargetGroup
+    Properties:
+      HealthCheckPath: /healthcheck
+      HealthCheckIntervalSeconds: 10
+      HealthCheckTimeoutSeconds: 6
+      HealthyThresholdCount: 2
+      UnhealthyThresholdCount: 3
+      TargetType: ip
+      Name: !Join ['-', [solid-prototype-app, TargetGroup]]
+      Port: !Ref ContainerPort
+      Protocol: HTTP
+      VpcId:
+        Fn::ImportValue:
+          Fn::Sub: "${CommonStackName}-VPCID"
+
+  LoadBalancerRule:
+    Type: AWS::ElasticLoadBalancingV2::ListenerRule
+    Properties:
+      Actions:
+        - TargetGroupArn: !Ref TargetGroup
+          Type: 'forward'
+      Conditions:
+        - Field: path-pattern
+          Values: ['*']
+      ListenerArn: !Ref LoadBalancerListener
+      Priority: 1
+
+  ExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Join ['-', [solid-prototype-app, ExecutionRole]]
+      AssumeRolePolicyDocument:
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: ecs-tasks.amazonaws.com
+            Action: 'sts:AssumeRole'
+      ManagedPolicyArns:
+        - 'arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy'
+
+  TaskRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Join ['-', [solid-prototype-app, TaskRole]]
+      AssumeRolePolicyDocument:
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: ecs-tasks.amazonaws.com
+            Action: 'sts:AssumeRole'
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy
+
+  ContainerSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: !Join ['-', [solid-prototype-app, ContainerSecurityGroup]]
+      VpcId:
+        Fn::ImportValue:
+          Fn::Sub: "${CommonStackName}-VPCID"
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: !Ref ContainerPort
+          ToPort: !Ref ContainerPort
+          SourceSecurityGroupId: !Ref LoadBalancerSecurityGroup
+
+  LoadBalancerSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: !Join ['-', [solid-prototype-app, LoadBalancerSecurityGroup]]
+      VpcId:
+        Fn::ImportValue:
+          Fn::Sub: "${CommonStackName}-VPCID"
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: 80
+          ToPort: 80
+          CidrIp: 0.0.0.0/0
+        - IpProtocol: tcp
+          FromPort: 443
+          ToPort: 443
+          CidrIp: 0.0.0.0/0
+
+  LoadBalancer:
+    Type: AWS::ElasticLoadBalancingV2::LoadBalancer
+    Properties:
+      Name: !Join ['-', [solid-prototype-app, LoadBalancer]]
+      Scheme: internet-facing
+      SecurityGroups:
+        - !Ref LoadBalancerSecurityGroup
+      Subnets:
+        - Fn::ImportValue:
+            Fn::Sub: "${CommonStackName}-PublicSubnet1ID"
+        - Fn::ImportValue:
+            Fn::Sub: "${CommonStackName}-PublicSubnet2ID"
+
+  LoadBalancerListener:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    Properties:
+      DefaultActions:
+        - Type: "redirect"
+          RedirectConfig:
+            Protocol: "HTTPS"
+            Port: 443
+            Host: "#{host}"
+            Path: "/#{path}"
+            Query: "#{query}"
+            StatusCode: "HTTP_301"
+      LoadBalancerArn: !Ref LoadBalancer
+      Port: 80
+      Protocol: HTTP
+
+  HTTPSLoadBalancerListener:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    Properties:
+      DefaultActions:
+        - TargetGroupArn: !Ref TargetGroup
+          Type: forward
+      LoadBalancerArn: !Ref LoadBalancer
+      Port: 443
+      Protocol: HTTPS
+      Certificates:
+      - CertificateArn: !Ref HTTPSCertificate
+      
+  HTTPSCertificate:
+    Type: AWS::CertificateManager::Certificate
+    Properties:
+      DomainName: prototype.solid.integration.account.gov.uk
+      DomainValidationOptions: 
+        - DomainName: prototype.solid.integration.account.gov.uk
+          HostedZoneId: 
+            Fn::ImportValue:
+              Fn::Sub: "${CommonStackName}-SolidRoute53"
+      ValidationMethod: DNS
+
+  DNSRecord:
+    Type: AWS::Route53::RecordSet
+    Properties:
+      Name: prototype.solid.integration.account.gov.uk
+      ResourceRecords:
+        - !GetAtt LoadBalancer.DNSName
+      HostedZoneId: 
+        Fn::ImportValue:
+          Fn::Sub: "${CommonStackName}-SolidRoute53"
+      Type: CNAME
+      TTL: 3000
 
 Outputs:
   RepositoryUrl:

--- a/infrastructure/prototype-app/template.yaml
+++ b/infrastructure/prototype-app/template.yaml
@@ -1,0 +1,16 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+
+Description: "Deploy the Solid proof of concept app"
+
+Resources:
+  ContainerRepository:
+    Type: AWS::ECR::Repository
+    Properties: 
+      ImageTagMutability: IMMUTABLE
+      RepositoryName: solid-prototype-app
+
+Outputs:
+  RepositoryUrl:
+    Description: The URL for the app's ECR image repository
+    Value: !GetAtt ContainerRepository.RepositoryUri

--- a/infrastructure/prototype-app/template.yaml
+++ b/infrastructure/prototype-app/template.yaml
@@ -12,7 +12,6 @@ Parameters:
     Default: common
   ImageTag:
     Type: String
-    Default: 9615586
 
 Resources:
   ContainerRepository:


### PR DESCRIPTION
We're not at CD yet, but this PR sets up everything we need to deploy the prototype app to https://prototype.solid.integration.account.gov.uk/ on ECS / Fargate. 

It borrows heavily from the CloudFormation we wrote before to deploy the demo Node app to Fargate.

`deploy.sh` in `infrastructure/prototype-app` does everything we need our CD tool to do, so hopefully it'll be fairly easy to  move over to a Github action in the near future.

Note that this specifies to deploy only one container. Initially we'll be using in-memory session management, so having multiple deployed containers brings the risk of requests being split between containers which will break as only one will have the session state.

I *think* it's possible to get the load balancer to do session-aware routing, but until we've confirmed that or set up an external session store we should keep this to a single container.