### PR TITLE
Explicitly set Rebase auto as debpendabot strategy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,4 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    rebase-strategy: "auto"


### PR DESCRIPTION
This is an odd one, when we update the main branch, it appears
dependabot is not automatically rebasing branches. I'm used to this
happening automatically.

[github says][1] these should happen automatically, and I'm assuming
that it's finding main ok as the [target-branch][2]. So lets try setting
this expicitly and see if that overrides any weirdness going on

[1]: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#rebase-strategy
[2]: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#target-branch