### PR TITLE
BAU: Use `npm ci` to install dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A prototype to evaluate Solid as a personal data store
 
 ## Running the prototype app
 
-1. Run `npm install` to install dependencies
+1. Run `npm ci` to install dependencies
 2. Run `npm run build` to build the app
 3. Run `npm start` to start the local server
 4. Visit `http://localhost:3000` in your browser 


### PR DESCRIPTION
This installs exactly what's in `package-lock.json` so developers
always have the same versions of everything when working on this app.

The CI workflow already used `npm ci` so doesn't need updating.