### PR TITLE
GUA-220: Forbid linter warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/app",
   "typings": "dist/app",
   "scripts": {
-    "lint": "eslint .",
+    "lint": "eslint . --max-warnings=0",
     "clean": "rm -rf dist",
     "build-sass": "rm -rf dist/public/stylesheets/application.css && sass --no-source-map src/public/stylesheets/application.scss dist/public/stylesheets/application.css --style compressed",
     "copy-assets": "mkdir -p dist/public/javascripts/govuk-frontend && cp node_modules/govuk-frontend/govuk/all.js dist/public/javascripts/govuk-frontend",

--- a/src/app.ts
+++ b/src/app.ts
@@ -39,7 +39,7 @@ const notFoundHandler: RequestHandler = (req, res, next) => {
 app.use(notFoundHandler);
 
 // error handler
-const errorHandler: ErrorRequestHandler = (err, req, res, next) => {
+const errorHandler: ErrorRequestHandler = (err, req, res) => {
   // set locals, only providing error in development
   res.locals.message = err.message;
   res.locals.error = req.app.get('env') === 'development' ? err : {};


### PR DESCRIPTION
Setting `--max-warnings=0` means that ESLint will error and raise an exit code 1 if there are any warnings found, which means that `npm run test` will fail.

Github has started showing these warnings in PR summaries, so this change will help us catch them earlier.

I recommend installing the [ESLint VSCode plugin](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint) which will highlight warnings and offer solutions in VSCode.

---

This does mean we have to put in a bit of extra effort to make sure our code is 'clean and tidy', but I think

1. It's not going to be a lot more effort
2. We should be working to best practices, even on a prototype project

It's open for discussion though - I think disabling warnings is quite an opinionated setting for our tooling.