### PR TITLE
Gua 220 fixes to ci

### DIFF
--- a/.github/workflows/build_and_deploy.yaml
+++ b/.github/workflows/build_and_deploy.yaml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+env:
+  AWS_REGION : "eu-west-2"
 
 jobs:
   deploy:
@@ -24,7 +26,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v1
         with:
           role-to-assume: ${{ secrets.GH_ACTIONS_ROLE_ARN }}
-          aws-region: "eu-west-2"
+          aws-region: ${{ env.AWS_REGION }}
 
       - name: Login to Amazon ECR
         id: login-ecr

--- a/.github/workflows/build_and_deploy.yaml
+++ b/.github/workflows/build_and_deploy.yaml
@@ -10,6 +10,7 @@ env:
 jobs:
   deploy:
     name: Deploy POC app to Fargate
+    environment: build
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:

--- a/infrastructure/prototype-app/template.yaml
+++ b/infrastructure/prototype-app/template.yaml
@@ -324,10 +324,5 @@ Outputs:
   RepositoryUrl:
     Description: The URL for the app's ECR image repository
     Value: !GetAtt ContainerRepository.RepositoryUri
-  GitHubIdentityProviderArn:
-    Description: The ARN of the GitHub identity provider
-    Value: !GetAtt GitHubIdentityProvider.Arn
-    Export:
-      Name: GitHubIdentityProviderArn
   GithubActionRole:
     Value: !GetAtt GithubActionRole.Arn

--- a/infrastructure/prototype-app/template.yaml
+++ b/infrastructure/prototype-app/template.yaml
@@ -152,7 +152,8 @@ Resources:
                 - !Ref GitHubIdentityProviderArn
             Condition:
               StringLike:
-                token.actions.githubusercontent.com:sub: !Sub repo:alphagov/di-solid-prototype:*
+                token.actions.githubusercontent.com:aud: sts.amazonaws.com
+                token.actions.githubusercontent.com:sub: repo:alphagov/di-solid-prototype:*
       ManagedPolicyArns:
         - !Ref GitHubActionsPolicy
       Tags:

--- a/infrastructure/prototype-app/template.yaml
+++ b/infrastructure/prototype-app/template.yaml
@@ -206,6 +206,7 @@ Resources:
 
   GitHubIdentityProvider:
     Type: AWS::IAM::OIDCProvider
+    Condition: CreateOIDCProvider
     Properties:
       ClientIdList:
         - "sts.amazonaws.com"


### PR DESCRIPTION
Three quick changes:
- Extend conditionality to the create oidc provider (following github docs)
- Tiny refactor to put amazon region at the top
- add aud to trust policy
- Finally it seems we couldn't find the secret because we weren't telling the job to run in the right env.

These have been SAM deployed and checked within AWS.