### PR TITLE
Try using aws-actions/aws-cloudformation-github-deploy

### DIFF
--- a/.github/workflows/build_and_deploy.yaml
+++ b/.github/workflows/build_and_deploy.yaml
@@ -6,14 +6,11 @@ on:
       - main
 env:
   AWS_REGION: eu-west-2
-  ECR_REPOSITORY: solid-prototype-app                             # set this to your Amazon ECR repository name
-  ECS_SERVICE: solid-prototype-app                                # set this to your Amazon ECS service name
-  ECS_CLUSTER: prototype-app-ECSCluster-PpwVfFNomNqq              # set this to your Amazon ECS cluster name
-  ECS_TASK_DEFINITION: .aws/task-definition.json                  # set this to the path to your Amazon ECS task definition
-                                                                  # file, e.g. .aws/task-definition.json
-  CONTAINER_NAME: solid-prototype-app                             # set this to the name of the container in the
-                                                                  # containerDefinitions section of your task definition
+  ECR_REPOSITORY: solid-prototype-app
   GITHUB_SESSION_NAME: SolidPOCDeploySession
+  IMAGE_TAG: ${{ github.sha }}
+  CF_STACK_NAME: prototype-app
+  CF_TEMPLATE_PATH: infrastructure/prototype-app/template.yaml
 
 jobs:
   deploy:
@@ -46,7 +43,6 @@ jobs:
         id: build-image
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          IMAGE_TAG: ${{ github.sha }}
         run: |
           # Build a docker container and
           # push it to ECR so that it can
@@ -55,18 +51,9 @@ jobs:
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
           echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
 
-      - name: Fill in the new image ID in the Amazon ECS task definition
-        id: task-def
-        uses: aws-actions/amazon-ecs-render-task-definition@v1
+      - name: Deploy to AWS CloudFormation
+        uses: aws-actions/aws-cloudformation-github-deploy@v1
         with:
-          task-definition: ${{ env.ECS_TASK_DEFINITION }}
-          container-name: ${{ env.CONTAINER_NAME }}
-          image: ${{ steps.build-image.outputs.image }}
-
-      - name: Deploy Amazon ECS task definition
-        uses: aws-actions/amazon-ecs-deploy-task-definition@v1
-        with:
-          task-definition: ${{ steps.task-def.outputs.task-definition }}
-          service: ${{ env.ECS_SERVICE }}
-          cluster: ${{ env.ECS_CLUSTER }}
-          wait-for-service-stability: true
+          name: $CF_STACK_NAME
+          template: $CF_TEMPLATE_PATH
+          parameter-overrides: "ParameterKey=ImageTag,ParameterValue=$IMAGE_TAG --confirm-changeset"


### PR DESCRIPTION
Previous attempts seemed to hit a brick wall. We wanted a task
definition to follow along with that github's guides wanted. They
suggsted that should be introduced as-code defined somewhere like
.aws/task-definition.json.

However we've defined ours in cloud formation, and I can't see a way to
supply it with the version that exists in AWS, and get it to pull JSON.

Looking at Alex's working deploy.sh though, we can perhaps skip all
that.

All we want to do is:
1. build a docker image (working!)
2. push it to ECR (working!)
3. sam deploy

I think this is what the new element in this commit should help with