### PR TITLE
GUA-205: Create a pod and WebID profile when a user first logs in

### DIFF
--- a/src/lib/pod.ts
+++ b/src/lib/pod.ts
@@ -1,0 +1,33 @@
+import { Session } from '@inrupt/solid-client-authn-node';
+import { getEssServiceURI, EssServices } from '../config';
+
+export async function createProfileAndPod(session: Session) {
+  if (session.info.webId) {
+    await session.fetch(session.info.webId, {method: 'POST'})
+    const provision = await (await session.fetch(getEssServiceURI(EssServices.Provision), {method: 'POST'})).json()
+
+    await session.fetch(
+      `${session.info.webId}/provision`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          '@context': {
+            'id':'@id',
+            'storage':{
+               '@type':'@id',
+               '@id':'http://www.w3.org/ns/pim/space#storage'
+            },
+            'profile':{
+               '@type':'@id',
+               '@id':'http://xmlns.com/foaf/0.1/isPrimaryTopicOf'
+            }
+         },
+         'id': session.info.webId,
+         'profile': provision['profile'],
+         'storage': provision['storage']
+        })
+      }
+    )
+  }
+}


### PR DESCRIPTION
Following the documentation at:

https://docs.inrupt.com/ess/latest/services/service-webid/#create-a-profile-document
https://docs.inrupt.com/ess/latest/services/service-pod-management/#provision-create-pod
https://docs.inrupt.com/ess/latest/services/service-webid/#add-pod-location-to-profile-document

If a user's WebID returns a 404 it means we've not created a profile
for them yet, so go through the process of:

1. Create a WebID profile
2. Create a pod
3. Add a link to that pod to the WebID profile