### PR TITLE
GUA-205: Fix local redirect URI

### DIFF
--- a/src/controllers/info.ts
+++ b/src/controllers/info.ts
@@ -18,7 +18,7 @@ export function buildClientIdDocument(): ClientIdDocument {
     ],
     "redirect_uris": [
       `${getHostname()}/login/callback`,
-      "https://localhost:3000/login/callback"
+      "http://localhost:3000/login/callback"
     ]
   }
 }

--- a/src/test/info.test.ts
+++ b/src/test/info.test.ts
@@ -33,7 +33,7 @@ describe("buildClientIdDocument", () => {
     })
 
     it("always includes the local callback URL in redirect_uris", () => {
-      expect(clientId["redirect_uris"]).to.include("https://localhost:3000/login/callback")
+      expect(clientId["redirect_uris"]).to.include("http://localhost:3000/login/callback")
     })
   })
 })


### PR DESCRIPTION
It needs to be `http` - we missed this in #55 