### PR TITLE
GUA-205: Use client ID on login 

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -6,8 +6,12 @@ export function getSessionKeys() {
   return ["key1", "key2"];
 }
 
+export function getDeployedDomain() {
+  return 'prototype.solid.integration.account.gov.uk'
+}
+
 export function getHostname() {
-  const hostname = process.env.NODE_ENV == 'production' ? 'prototype.solid.integration.account.gov.uk' : `localhost:${getPort()}`
+  const hostname = process.env.NODE_ENV == 'production' ? getDeployedDomain() : `localhost:${getPort()}`
   return `${getProtocol()}://${hostname}`;
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -28,3 +28,17 @@ export function getClientId(environment?: string) {
   }
   return `${hostname}/info/id`
 }
+
+export enum EssServices {
+  Authorization = 'authorization',
+  Provision = 'provision',
+  Storage = 'storage',
+  OpenId = 'openid',
+  Id = 'id',
+  Uma = 'uma',
+  Vc = 'vc'
+}
+
+export function getEssServiceURI(service: EssServices) {
+  return `https://${service}.ess.solid.integration.account.gov.uk`
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,5 @@
 export function getPort() {
-  return process.env.LOGS_LEVEL || 3000;
+  return process.env.PORT || 3000;
 }
 
 export function getSessionKeys() {

--- a/src/config.ts
+++ b/src/config.ts
@@ -19,6 +19,12 @@ export function getProtocol() {
   return process.env.NODE_ENV == 'production' ? 'https' : 'http';
 }
 
-export function getClientId() {
-  return `${getHostname()}/info/id`
+export function getClientId(environment?: string) {
+  let hostname: string;
+  if (environment && environment == 'production') {
+    hostname = `https://${getDeployedDomain()}`
+  } else {
+    hostname = getHostname();
+  }
+  return `${hostname}/info/id`
 }

--- a/src/controllers/login.ts
+++ b/src/controllers/login.ts
@@ -1,7 +1,7 @@
 import { Request, Response } from "express";
 import { getSessionFromStorage, Session } from "@inrupt/solid-client-authn-node";
 
-import { getHostname, getClientId } from "../config";
+import { getHostname, getClientId, getEssServiceURI, EssServices } from "../config";
 
 export async function loginGet(req: Request, res: Response): Promise<void> {
   res.render('login/start');
@@ -15,8 +15,8 @@ export async function loginPost(req: Request, res: Response): Promise<void> {
   const redirectToSolidIdentityProvider = (url: string) => { res.redirect(url); };
   await session.login({
     redirectUrl: `${getHostname()}/login/callback`,
-    oidcIssuer: "https://openid.ess.solid.integration.account.gov.uk/",
     clientId: getClientId('production'),
+    oidcIssuer: getEssServiceURI(EssServices.OpenId),
     handleRedirect: redirectToSolidIdentityProvider,
   });
 }

--- a/src/controllers/login.ts
+++ b/src/controllers/login.ts
@@ -1,7 +1,7 @@
 import { Request, Response } from "express";
 import { getSessionFromStorage, Session } from "@inrupt/solid-client-authn-node";
 
-import { getHostname } from "../config";
+import { getHostname, getClientId } from "../config";
 
 export async function loginGet(req: Request, res: Response): Promise<void> {
   res.render('login/start');
@@ -16,7 +16,7 @@ export async function loginPost(req: Request, res: Response): Promise<void> {
   await session.login({
     redirectUrl: `${getHostname()}/login/callback`,
     oidcIssuer: "https://openid.ess.solid.integration.account.gov.uk/",
-    clientName: "GDS Solid proof of concept app",
+    clientId: getClientId('production'),
     handleRedirect: redirectToSolidIdentityProvider,
   });
 }

--- a/src/test/config.test.ts
+++ b/src/test/config.test.ts
@@ -1,0 +1,17 @@
+import { describe } from "mocha";
+import { expect } from "./utils/test";
+import { getClientId, getDeployedDomain, getHostname } from "../config"
+
+describe("config", () => {
+  describe("getClientId", () => {
+    it("returns the expected client ID URI", () => {
+      const clientId = getClientId();
+      expect(clientId).to.eq(`${getHostname()}/info/id`)
+    })
+
+    it("returns the production URI when `environment` is set", () => {
+      const clientId = getClientId('production');
+      expect(clientId).to.eq(`https://${getDeployedDomain()}/info/id`)
+    })
+  })
+})


### PR DESCRIPTION
Now we have a client ID document for this app (see #55) we can use it and the information it contains while logging in, instead of providing a client name etc. directly. 

This also means we can add this client ID to the allowlist in ESS, which will permit this app to create WebID profiles and pods on behalf of users.

I've also cherry-picked in 4c8f1483e5eb14680000e20ed081b391a5f6395b from #54 because I got bored of typing the domain out each time. 