### PR TITLE
GUA-230: Allow fetching a refresh token

### DIFF
--- a/src/controllers/info.ts
+++ b/src/controllers/info.ts
@@ -19,7 +19,9 @@ export function buildClientIdDocument(): ClientIdDocument {
     "redirect_uris": [
       `${getHostname()}/login/callback`,
       "http://localhost:3000/login/callback"
-    ]
+    ],
+    "scope" : "openid profile offline_access webid",
+    "grant_types" : ["refresh_token","authorization_code"],
   }
 }
 
@@ -30,4 +32,6 @@ export type ClientIdDocument = {
   client_uri: string;
   post_logout_redirect_uris: string[];
   redirect_uris: string[];
+  scope: string;
+  grant_types: string[];
 }

--- a/src/test/info.test.ts
+++ b/src/test/info.test.ts
@@ -22,6 +22,15 @@ describe("buildClientIdDocument", () => {
     expect(clientId["client_id"]).to.eq(getClientId())
   })
 
+  it("includes the values required for a refresh token and offline access", () => {
+    expect(clientId["grant_types"]).to.include("refresh_token")
+    expect(clientId["scope"]).to.match(/offline_access/)
+  })
+
+  it("has a valid format for scope", () => {
+    expect(clientId["scope"]).to.match(/[\w\s]+/)
+  })
+
   describe("when the app is deployed", () => {
     before(() => {
       process.env.NODE_ENV = 'production'


### PR DESCRIPTION
Update the Solid-OIDC client ID document to include the scopes and
grant types that allow the app to request a refresh token.

This is because we need a refresh token in order to make further calls
to ESS on pages after the login callback. The Solid client library will
handle including the refresh token in any further calls of `Session.fetch`
so this should be all that's needed to get the read / write functionality
in #37 working again.