### PR TITLE
BAU: Set dependabot checks to weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,5 +3,5 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     rebase-strategy: "auto"


### PR DESCRIPTION
We've had 3 patch versions of `@typescript-eslint/parser` and 2 of
`@types/node` in the last three days.

It's a bit annoying for these to keep coming up and this is a
non-production, proof-of-concept project so it's not critical that we
keep up to date with the most recent versions of everything. We also
have to wait for deploys to finish before merging another PR, so if
there are loads of dependabot updates we have to keep coming back to
them (as `sam deploy` fails when the stack is already in an `UPDATING`
state).

Setting he dependency checks to run weekly instead of daily is a good
compromise between staying up to date and keeping our time free.