### PR TITLE
GUA 209: save identity

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -14,6 +14,7 @@ import { indexRouter } from "./routes/index";
 import { loginRouter } from "./routes/login";
 import { infoRouter } from "./routes/info";
 import { accessRouter } from "./routes/access";
+import { identityRouter } from "./routes/identity";
 
 const app: express.Application = express();
 
@@ -36,6 +37,7 @@ app.use('/', indexRouter);
 app.use('/login', loginRouter);
 app.use('/info', infoRouter);
 app.use('/access-logs', accessRouter);
+app.use('/identity', identityRouter);
 
 nunjucks.configure(
   ['dist/views', 'node_modules/govuk-frontend/'], 

--- a/src/controllers/identity/save.ts
+++ b/src/controllers/identity/save.ts
@@ -1,0 +1,5 @@
+import { Request, Response } from "express";
+
+export function saveGet(req: Request, res: Response) {
+    res.render('identity/save');
+}

--- a/src/routes/identity.ts
+++ b/src/routes/identity.ts
@@ -1,0 +1,9 @@
+import express from "express";
+import { saveGet } from "../controllers/identity/save"
+
+const router = express.Router();
+
+/* GET Save your identity page. */
+router.get('/save', saveGet);
+
+export { router as identityRouter };

--- a/src/views/identity/save.njk
+++ b/src/views/identity/save.njk
@@ -1,0 +1,45 @@
+{% extends "govuk/template.njk" %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% block head %}
+  <!--[if !IE 8]><!-->
+    <link href="/stylesheets/application.css" rel="stylesheet">
+  <!--<![endif]-->
+
+  {# For Internet Explorer 8, you need to compile specific stylesheet #}
+  {# see https://frontend.design-system.service.gov.uk/supporting-ie8/#support-internet-explorer-8 #}
+  <!--[if IE 8]>
+    <link href="/govuk-frontend/all-ie8.css" rel="stylesheet">
+  <![endif]-->
+
+  {# For older browsers to allow them to recognise HTML5 elements such as `<header>` #}
+  <!--[if lt IE 9]>
+    <script src="/html5-shiv/html5shiv.js"></script>
+  <![endif]-->
+{% endblock %}
+
+{% block content %}
+  <h1 class="govuk-heading-xl">You’ve successfully proved your identity</h1>
+
+  <p class="govuk-body">
+    You can save your proof of identity to your GOV.UK account so you can skip these questions next time a service needs to check who you are. 
+  </p>
+
+  <form action="/identity/save/" method="post">
+    {{ govukButton({
+      text: "Save proof of identity to your GOV.UK account",
+      type: "submit"
+    }) }}
+  </form>
+
+  <a class="govuk-link" href="/identity/continue">
+    Do not save proof of identity and continue to DBS
+  </a>
+
+{% endblock %}
+
+{% block bodyEnd %}
+  {# Run JavaScript at end of the <body>, to avoid blocking the initial render. #}
+  <script src="/javascripts/govuk-frontend/all.js"></script>
+  <script>window.GOVUKFrontend.initAll()</script>
+{% endblock %}


### PR DESCRIPTION
This isn't exactly a coherent feature yet.
But my hope is this sketches out enough of where the rest of the [Identity screens](https://www.figma.com/file/f6Kn3ZhjCiiJSIQpNFt7On/Solid-example-flows?node-id=966%3A1186) can go, so those can start filling in.

Next up, still a part of GUA 209, well try and write a fixture to the pod on a post to the /identity/save path.