### PR TITLE
Fix `govuk-frontend` assets 404-ing on local

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -89,7 +89,7 @@ function configureNunjucks(
 
   app.set("view engine", "njk");
 
-  app.use('/assets', express.static(path.join(__dirname, '/node_modules/govuk-frontend/govuk/assets')))
+  app.use('/assets', express.static(path.resolve('node_modules/govuk-frontend/govuk/assets')))
 
   // Set up server
 


### PR DESCRIPTION
There is a dependency on static assets from `govuk-frontend` (aka the
Design System), such as fonts. Static asset requests were returning 404s.
This updates the code so that express can get those static files from
the relevant location under `node_modules`.

## Before: wrong font
<img width="1675" alt="Screenshot 2022-07-12 at 17 51 21" src="https://user-images.githubusercontent.com/7116819/178550128-e9dfc59a-0bcf-4322-b954-a22fcccd81f8.png">

## After: correct font
<img width="1676" alt="Screenshot 2022-07-12 at 17 52 21" src="https://user-images.githubusercontent.com/7116819/178550136-bed681ba-ba22-4e0a-b0c4-f4e2ef0d8dfe.png">
