### PR TITLE
GUA-210: static views for account home & subpages

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -43,7 +43,7 @@ app.use('/login', loginRouter);
 app.use('/info', infoRouter);
 app.use('/access-logs', accessRouter);
 app.use('/identity', identityRouter);
-app.use(accountRouter);
+app.use('/account', accountRouter);
 
 i18next
   .use(Backend)

--- a/src/app.ts
+++ b/src/app.ts
@@ -16,6 +16,7 @@ import { infoRouter } from "./routes/info";
 import { accessRouter } from "./routes/access";
 import { identityRouter } from "./routes/identity";
 import { Environment } from "nunjucks";
+import { accountRouter } from "./routes/account";
 
 import i18next from "i18next";
 import i18nextMiddleware from "i18next-http-middleware";
@@ -42,6 +43,7 @@ app.use('/login', loginRouter);
 app.use('/info', infoRouter);
 app.use('/access-logs', accessRouter);
 app.use('/identity', identityRouter);
+app.use(accountRouter);
 
 i18next
   .use(Backend)

--- a/src/controllers/account.ts
+++ b/src/controllers/account.ts
@@ -1,0 +1,21 @@
+import { Request, Response } from "express";
+
+export async function accountSettingsGet(req: Request, res: Response): Promise<void> {
+  res.render('account/settings');
+}
+
+export async function accountActivityGet(req: Request, res: Response): Promise<void> {
+  res.render('account/activity');
+}
+
+export async function accountHomeGet(req: Request, res: Response): Promise<void> {
+  res.render('account/home');
+}
+
+export async function yourProofOfIdGet(req: Request, res: Response): Promise<void> {
+  res.render('account/your-proof-of-identity');
+}
+
+export async function deleteYourProofOfIdGet(req: Request, res: Response): Promise<void> {
+  res.render('account/delete-proof-of-identity');
+}

--- a/src/controllers/identity/save.ts
+++ b/src/controllers/identity/save.ts
@@ -46,7 +46,7 @@ export async function savePost(req: Request, res: Response): Promise<void> {
   const GOV_UK_CREDENTIAL = "https://vocab.account.gov.uk/GovUKCredential";
   const GOV_UK_hasCredential = "https://vocab.account.gov.uk/hasCredential";
   const session = await getSessionFromStorage(req.session?.sessionId);
-  
+
   if (session != undefined) {
     const containerUri = await getDatasetUri(session, "private/govuk/identity/poc/credentials-pat/vcs/");
     const metadataUri = `${containerUri}/vc-metadata`
@@ -81,7 +81,7 @@ export async function savePost(req: Request, res: Response): Promise<void> {
 // If the targetFileURL does not exist, create the file at the location.
 async function writeFileToPod(file: Blob, targetFileURL: string, session: Session ) {
   try {
-    const savedFile = await overwriteFile(  
+    const savedFile = await overwriteFile(
       targetFileURL,                                      // URL for the file.
       // We need to explicitly convert our 'Blob' into a Buffer here (see
       // detailed comment on our 'import { Blob }' code above).

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -3,7 +3,6 @@
     "back": "Back",
     "continue": "Continue",
     "change": "Change",
-    "start": "Start",
     "errorTitlePrefix": "Error",
     "footer": {
       "accessibilityStatement": {
@@ -23,11 +22,13 @@
         "linkText": "Privacy notice"
       }
     },
+    "on": "on",
     "phaseBanner": {
       "tag": "beta",
       "text": "This is a new service – your <a  href=\"/feedback\" class=\"govuk-link\">feedback</a> will help us to improve it."
     },
-    "postcode": "Postcode"
+    "postcode": "Postcode",
+    "start": "Start"
   },
   "identity": {
     "checkYourDetails": {
@@ -169,6 +170,77 @@
       "heading": "Use your saved proof of identity to continue",
       "paragraph1": "You need to prove your identity before you [doThing].",
       "paragraph2": "Your GOV.UK account will check your saved proof of identity to confirm it’s really you."
+    }
+  },
+  "account": {
+    "serviceName": "GOV.UK Account",
+    "header": {
+      "homepageHref": "https://www.gov.uk/",
+      "accountLink": "Account home",
+      "accountSettingsLink": "Account settings",
+      "signOutLink": "Sign out"
+    },
+    "pages": {
+      "activity": {
+        "title": "Account activity",
+        "contactUs": "If you see something you do not recognise, <a class=\"govuk-link\" href=\"[contactUsLink]\">contact us</a>."
+      },
+      "home": {
+        "title": "Your GOV.UK account",
+        "header": "Your GOV.UK account",
+        "signedInStatus": "You’re signed in as",
+        "servicesHeading": "Services you’ve used with your GOV.UK account",
+
+        "IdServicesHeading": "Services that have checked your identity",
+        "IdServicesParagraph": "You’ve used your GOV.UK account to prove your identity to the following services:",
+        "aboutAccounts": {
+          "heading": "About GOV.UK accounts",
+          "paragraph1": "GOV.UK accounts are new. At the moment you can only use your GOV.UK account with a few services.",
+          "paragraph2": "GOV.UK accounts are currently separate from other government accounts (for example Government Gateway or Universal Credit).",
+          "paragraph3": "In the future, you’ll be able to use your GOV.UK account to sign in to most services on GOV.UK."
+        }
+      },
+      "settings": {
+        "title": "GOV.UK account settings",
+        "accountDetails": "Your sign in details",
+        "summaryList": {
+          "email": "Email address",
+          "password": "Password",
+          "phoneNumber": "Phone number",
+          "changeAction": "Change"
+        },
+        "yourProofOfId": {
+          "heading": "Your proof of identity",
+          "link": "View your saved proof of identity",
+          "info": "You’ve saved your proof of identity to your account. Your account will check it each time a service needs to confirm who you are."
+        },
+        "yourAccountActivity": {
+          "heading": "View your account activity",
+          "link": "View your account activity",
+          "info": "See when you’ve signed in and how your account has used your saved information."
+        },
+        "deleteAccount": {
+          "heading": "Delete your GOV.UK account",
+          "link": "Delete your GOV.UK account",
+          "info": "This will permanently delete your GOV.UK account. You’ll no longer be able to sign in to the services you’ve used with your account."
+        },
+        "deletedProofOfIdSuccess": "You’ve deleted your proof of identity"
+      },
+      "yourProofOfId": {
+        "title": "Your proof of identity",
+        "paragraph1": "Your GOV.UK account proves your identity with information you’ve provided.",
+        "paragraph2": "Your account checks this information to prove your identity every time you use a service that requires it.",
+        "summaryListTitle": "Information you’ve provided to prove your identity",
+        "deleteInformationLink": "Delete this information from your account",
+        "savedOn": "Saved on [date]"
+      },
+      "deleteProofOfId": {
+        "title": "Delete the information you use to prove your identity",
+        "paragraph1": "Confirm you want to permanently delete the information your GOV.UK account uses to prove your identity. This will not delete your account.",
+        "paragraph2": "You will need to go through the process of proving your identity next time you use a service that requires it.",
+        "buttonText": "Delete identity information",
+        "cancelLink": "Do not delete your information"
+      }
     }
   }
 }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -3,7 +3,6 @@
     "back": "Back",
     "continue": "Continue",
     "change": "Change",
-    "start": "Start",
     "errorTitlePrefix": "Error",
     "footer": {
       "accessibilityStatement": {
@@ -23,11 +22,13 @@
         "linkText": "Privacy notice"
       }
     },
+    "on": "on",
     "phaseBanner": {
       "tag": "beta",
       "text": "This is a new service – your <a  href=\"/feedback\" class=\"govuk-link\">feedback</a> will help us to improve it."
     },
-    "postcode": "Postcode"
+    "postcode": "Postcode",
+    "start": "Start"
   },
   "identity": {
     "checkYourDetails": {
@@ -169,6 +170,77 @@
       "heading": "Use your saved proof of identity to continue",
       "paragraph1": "You need to prove your identity before you [doThing].",
       "paragraph2": "Your GOV.UK account will check your saved proof of identity to confirm it’s really you."
+    }
+  },
+  "account": {
+    "serviceName": "GOV.UK Account",
+    "header": {
+      "homepageHref": "https://www.gov.uk/",
+      "accountLink": "Account home",
+      "accountSettingsLink": "Account settings",
+      "signOutLink": "Sign out"
+    },
+    "pages": {
+      "activity": {
+        "title": "Account activity",
+        "contactUs": "If you see something you do not recognise, <a class=\"govuk-link\" href=\"[contactUsLink]\">contact us</a>."
+      },
+      "home": {
+        "title": "Your GOV.UK account",
+        "header": "Your GOV.UK account",
+        "signedInStatus": "You’re signed in as",
+        "servicesHeading": "Services you’ve used with your GOV.UK account",
+
+        "IdServicesHeading": "Services that have checked your identity",
+        "IdServicesParagraph": "You’ve used your GOV.UK account to prove your identity to the following services:",
+        "aboutAccounts": {
+          "heading": "About GOV.UK accounts",
+          "paragraph1": "GOV.UK accounts are new. At the moment you can only use your GOV.UK account with a few services.",
+          "paragraph2": "GOV.UK accounts are currently separate from other government accounts (for example Government Gateway or Universal Credit).",
+          "paragraph3": "In the future, you’ll be able to use your GOV.UK account to sign in to most services on GOV.UK."
+        }
+      },
+      "settings": {
+        "title": "GOV.UK account settings",
+        "accountDetails": "Your sign in details",
+        "summaryList": {
+          "email": "Email address",
+          "password": "Password",
+          "phoneNumber": "Phone number",
+          "changeAction": "Change"
+        },
+        "yourProofOfId": {
+          "heading": "Your proof of identity",
+          "link": "View your saved proof of identity",
+          "info": "You’ve saved your proof of identity to your account. Your account will check it each time a service needs to confirm who you are."
+        },
+        "yourAccountActivity": {
+          "heading": "View your account activity",
+          "link": "View your account activity",
+          "info": "See when you’ve signed in and how your account has used your saved information."
+        },
+        "deleteAccount": {
+          "heading": "Delete your GOV.UK account",
+          "link": "Delete your GOV.UK account",
+          "info": "This will permanently delete your GOV.UK account. You’ll no longer be able to sign in to the services you’ve used with your account."
+        },
+        "deletedProofOfIdSuccess": "You’ve deleted your proof of identity"
+      },
+      "yourProofOfId": {
+        "title": "Your proof of identity",
+        "paragraph1": "Your GOV.UK account proves your identity with information you’ve provided.",
+        "paragraph2": "Your account checks this information to prove your identity every time you use a service that requires it.",
+        "summaryListTitle": "Information you’ve provided to prove your identity",
+        "deleteInformationLink": "Delete this information from your account",
+        "savedOn": "Saved on [date]"
+      },
+      "deleteProofOfId": {
+        "title": "Delete the information you use to prove your identity",
+        "paragraph1": "Confirm you want to permanently delete the information your GOV.UK account uses to prove your identity. This will not delete your account.",
+        "paragraph2": "You will need to go through the process of proving your identity next time you use a service that requires it.",
+        "buttonText": "Delete identity information",
+        "cancelLink": "Do not delete your information"
+      }
     }
   }
 }

--- a/src/public/stylesheets/application.scss
+++ b/src/public/stylesheets/application.scss
@@ -1,1 +1,33 @@
 @import "../../../node_modules/govuk-frontend/govuk/all";
+
+.information-box {
+  margin-bottom: govuk-spacing(4);
+  padding: govuk-spacing(3);
+  background: govuk-colour("light-grey");
+  @include govuk-media-query($from: tablet) {
+    padding: govuk-spacing(6);
+    margin-top: govuk-spacing(2);
+    margin-bottom: govuk-spacing(8);
+  }
+}
+
+.accounts-panel {
+  padding: govuk-spacing(6);
+  border: solid 1px govuk-colour("mid-grey");
+  border-top: solid 3px $govuk-brand-colour;
+  margin-bottom: govuk-spacing(6);
+}
+
+.accounts-table {
+  @include govuk-media-query($until: tablet) {
+    .govuk-table__header,
+    .govuk-table__cell {
+      width: 100%;
+      display: block;
+      border: none;
+    }
+    .govuk-table__row {
+      border-bottom: 1px solid govuk-colour("mid-grey");
+    }
+  }
+}

--- a/src/routes/account.ts
+++ b/src/routes/account.ts
@@ -9,10 +9,10 @@ import {
 
 const router = express.Router();
 
-router.get('/account', accountHomeGet);
-router.get('/account/settings', accountSettingsGet);
-router.get('/account/settings/activity', accountActivityGet);
-router.get('/account/settings/your-proof-of-identity', yourProofOfIdGet);
-router.get('/account/settings/your-proof-of-identity/delete', deleteYourProofOfIdGet);
+router.get('/', accountHomeGet);
+router.get('/settings', accountSettingsGet);
+router.get('/settings/activity', accountActivityGet);
+router.get('/settings/your-proof-of-identity', yourProofOfIdGet);
+router.get('/settings/your-proof-of-identity/delete', deleteYourProofOfIdGet);
 
 export {router as accountRouter};

--- a/src/routes/account.ts
+++ b/src/routes/account.ts
@@ -1,0 +1,18 @@
+import express from "express";
+import {
+  accountHomeGet,
+  accountActivityGet,
+  accountSettingsGet,
+  yourProofOfIdGet,
+  deleteYourProofOfIdGet
+} from "../controllers/account"
+
+const router = express.Router();
+
+router.get('/account', accountHomeGet);
+router.get('/account/settings', accountSettingsGet);
+router.get('/account/settings/activity', accountActivityGet);
+router.get('/account/settings/your-proof-of-identity', yourProofOfIdGet);
+router.get('/account/settings/your-proof-of-identity/delete', deleteYourProofOfIdGet);
+
+export {router as accountRouter};

--- a/src/views/account/activity.njk
+++ b/src/views/account/activity.njk
@@ -1,0 +1,34 @@
+{% extends "layouts/account.njk" %}
+{% from "govuk/components/table/macro.njk" import govukTable %}
+{% set pageTitleName = 'account.pages.activity.title' | translate %}
+{% set activeNavLink = '/account/settings'%}
+{% set contactUsLink = '/account/contact'%}
+{% set backLink =  activeNavLink %}
+
+{% block content %}
+  <h1 class="govuk-heading-l govuk-!-margin-bottom-7">{{ pageTitleName }}</h1>
+  {{ govukTable({
+      classes: "accounts-table",
+      rows: [
+        [
+          {
+            text: "22 June 2022 at 09:25",
+            classes: "govuk-!-width-one-half"
+          },
+          {
+            text: "did an important thing on your GOV.UK account"
+          }
+        ],
+        [
+          {
+            text: "20 June 2022 at 12:08",
+            classes: "govuk-!-width-one-half"
+          },
+          {
+            text: "Did something else"
+          }
+        ]
+      ]
+  }) }}
+  <p class="govuk-body">{{ 'account.pages.activity.contactUs' | translate | replace("[contactUsLink]", contactUsLink) | safe }}</p>
+{% endblock %}

--- a/src/views/account/delete-proof-of-identity.njk
+++ b/src/views/account/delete-proof-of-identity.njk
@@ -1,0 +1,20 @@
+{% extends "layouts/account.njk" %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% set pageTitleName = 'account.pages.deleteProofOfId.title' | translate %}
+{% set activeNavLink = '/account/settings' %}
+{% set backLink =  '/account/settings/your-proof-of-identity' %}
+
+{% block content %}
+  <h1 class="govuk-heading-l govuk-!-margin-bottom-7">{{ 'account.pages.deleteProofOfId.title' | translate }}</h1>
+  <p class="govuk-body">{{ 'account.pages.deleteProofOfId.paragraph1' | translate }}</p>
+  <p class="govuk-body">{{ 'account.pages.deleteProofOfId.paragraph2' | translate }}</p>
+
+  <form action="" method="post">
+    {{ govukButton({
+      text: 'account.pages.deleteProofOfId.buttonText' | translate,
+      classes: "govuk-button--warning"
+    }) }}
+  </form>
+  <a href="{{ backLink }}" class="govuk-link govuk-body">{{ 'account.pages.deleteProofOfId.cancelLink' | translate }}</a>
+
+{% endblock %}

--- a/src/views/account/home.njk
+++ b/src/views/account/home.njk
@@ -1,0 +1,73 @@
+{% extends "layouts/account.njk" %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% set pageTitleName = 'account.pages.home.title' | translate %}
+{% set activeNavLink = '/account' %}
+{% set email = 'something@somewhere.com' %}
+{# Services you've used with your account, hard coded this for now #}
+{% set services = [{
+  name: "Personal tax account",
+  description:"Check your records and manage your payments to HM Revenue and Customs (HMRC).",
+  link: {
+    href: "#",
+    text: "Go to your personal tax account"
+  },
+  timeLastUsed: "20 June 2022"
+}] %}
+
+{# Services which have used your proof of id, hard coded this for now #}
+{% set idServices = [{
+  link: {
+    href: "#",
+    text: "Personal tax account"
+  },
+  timeLastChecked: "20 June 2022"
+  },{
+    link: {
+      href: "#",
+      text: "Request a basic DBS check"
+    },
+    timeLastChecked: "18 June 2022"
+  }]
+%}
+
+{% block content %}
+  <h1 class="govuk-heading-xl">{{ 'account.pages.home.title' | translate }}</h1>
+  <p class="govuk-body">{{ 'account.pages.home.signedInStatus' | translate }} <strong>{{ email }}</strong></p>
+  <hr class="govuk-section-break govuk-section-break--m">
+  {% if services %}
+    <section class="govuk-!-margin-bottom-8">
+      <h2 class="govuk-heading-m">{{ 'account.pages.home.servicesHeading' | translate }}</h2>
+      {% for service in services %}
+        <div class="accounts-panel">
+          <h3 class="govuk-heading-s">{{service.name}}</h3>
+          <p class="govuk-body">{{service.description}}</p>
+          <p class="govuk-body"><a class="govuk-link" href="{{service.link.href}}">{{service.link.text}}</a></p>
+          <p class="govuk-body govuk-hint"> Last used: {{service.timeLastUsed}}</p>
+        </div>
+      {% endfor %}
+    </section>
+  {% endif %}
+
+  {% if idServices %}
+    <section class="govuk-!-margin-bottom-8">
+      <h2 class="govuk-heading-m">{{ 'account.pages.home.IdServicesHeading' | translate }}</h2>
+      <p class="govuk-body">{{ 'account.pages.home.IdServicesParagraph' | translate }}</p>
+      <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-7">
+        {% for service in idServices %}
+          <li>
+            <a href="{{service.link.href}}">{{service.link.text}}</a> ({{ 'general.on' | translate }} {{service.timeLastChecked}})
+          </li>
+        {% endfor %}
+      </ul>
+      <p class="govuk-body">
+        <a href="/account/settings/your-proof-of-identity" class="govuk-link">{{ 'account.pages.settings.yourProofOfId.link' | translate }}</a>
+      </p>
+    </section>
+  {% endif %}
+  <section class="information-box">
+    <h2 class="govuk-heading-m">{{ 'account.pages.home.aboutAccounts.heading' | translate }}</h2>
+    <p class="govuk-body">{{ 'account.pages.home.aboutAccounts.paragraph1' | translate }}</p>
+    <p class="govuk-body">{{ 'account.pages.home.aboutAccounts.paragraph2' | translate }}</p>
+    <p class="govuk-body">{{ 'account.pages.home.aboutAccounts.paragraph3' | translate }}</p>
+  </section>
+{% endblock %}

--- a/src/views/account/settings.njk
+++ b/src/views/account/settings.njk
@@ -1,0 +1,94 @@
+{% extends "layouts/account.njk" %}
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
+{% set pageTitleName = 'account.pages.settings.title' | translate %}
+{% set activeNavLink = '/account/settings' %}
+{% set hasProofOfId = true %}
+{% set showSuccessMessage = false %}
+{% set successMessage %}
+  <h3 class="govuk-notification-banner__heading">
+    {{ 'account.pages.settings.deletedProofOfIdSuccess' | translate }}
+  </h3>
+{% endset %}
+
+{% block content %}
+  {% if showSuccessMessage %}
+    {{ govukNotificationBanner({
+      html: successMessage,
+      type: 'success'
+    }) }}
+  {% endif %}
+  <h1 class="govuk-heading-l govuk-!-margin-bottom-7">{{ 'account.pages.settings.title' | translate }}</h1>
+  <h2 class="govuk-heading-m">{{ 'account.pages.settings.accountDetails' | translate }}</h2>
+  {{ govukSummaryList({
+      classes:"accounts-summary-list",
+      rows: [
+          {
+              key: {
+                  text: 'account.pages.settings.summaryList.email' | translate
+              },
+              value: {
+                  text: 'email@test.com'
+              },
+              actions: {
+                  items: [
+                      {
+                          href: "/enter-password?type=changeEmail",
+                          text: 'account.pages.settings.summaryList.changeAction' | translate,
+                          visuallyHiddenText: 'account.pages.settings.summaryList.email' | translate
+                      }
+                  ]
+              }
+          },
+          {
+              key: {
+                  text: 'account.pages.settings.summaryList.password' | translate
+              },
+              value: {
+                  text: "••••••••••••••••"
+              },
+              actions: {
+                  items: [
+                      {
+                          href: "/enter-password?type=changePassword",
+                          text: 'account.pages.settings.summaryList.changeAction' | translate,
+                          visuallyHiddenText: 'account.pages.settings.summaryList.password' | translate
+                      }
+                  ]
+              }
+          },
+          {
+              key: {
+                  text: 'account.pages.settings.summaryList.phoneNumber' | translate
+              },
+              value: {
+                  text: '07111111111'
+              },
+              actions: {
+                  items: [
+                      {
+                          href: "/enter-password?type=changePhoneNumber",
+                          text: 'account.pages.settings.summaryList.changeAction' | translate,
+                          visuallyHiddenText: 'account.pages.settings.summaryList.phoneNumber' | translate
+                      }
+                  ]
+              }
+          }
+      ]
+  }) }}
+  <hr class="govuk-section-break govuk-section-break--m">
+  {% if hasProofOfId %}
+    <h2 class="govuk-heading-m">{{ 'account.pages.settings.yourProofOfId.heading' | translate }}</h2>
+    <p class="govuk-body">{{ 'account.pages.settings.yourProofOfId.info' | translate }}</p>
+    <a href="/account/settings/your-proof-of-identity" class="govuk-link govuk-body">{{ 'account.pages.settings.yourProofOfId.link' | translate }}</a>
+    <hr class="govuk-section-break govuk-section-break--m">
+  {% endif %}
+  <h2 class="govuk-heading-m">{{ 'account.pages.settings.yourAccountActivity.heading' | translate }}</h2>
+  <p class="govuk-body">{{ 'account.pages.settings.yourAccountActivity.info' | translate }}</p>
+  <a href="/account/settings/activity" class="govuk-link govuk-body">{{ 'account.pages.settings.yourAccountActivity.link' | translate }}</a>
+  <hr class="govuk-section-break govuk-section-break--m">
+  <h2 class="govuk-heading-m">{{ 'account.pages.settings.deleteAccount.heading' | translate }}</h2>
+  <p class="govuk-body">{{ 'account.pages.settings.deleteAccount.info' | translate }}</p>
+  <a href="/enter-password?type=deleteAccount" class="govuk-link govuk-body">{{ 'account.pages.settings.deleteAccount.link' | translate }}</a>
+  <hr class="govuk-section-break govuk-section-break--m">
+{% endblock %}

--- a/src/views/account/your-proof-of-identity.njk
+++ b/src/views/account/your-proof-of-identity.njk
@@ -1,0 +1,38 @@
+{% extends "layouts/account.njk" %}
+{% from "govuk/components/table/macro.njk" import govukTable %}
+{% set pageTitleName = 'account.pages.yourProofOfId.title' | translate %}
+{% set activeNavLink = '/account/settings'%}
+{% set backLink =  '/account/settings' %}
+
+{% block content %}
+  <h1 class="govuk-heading-l govuk-!-margin-bottom-7">{{ 'account.pages.yourProofOfId.title' | translate }}</h1>
+  <p class="govuk-body">{{ 'account.pages.yourProofOfId.paragraph1' | translate }}</p>
+  <p class="govuk-body">{{ 'account.pages.yourProofOfId.paragraph2' | translate }}</p>
+  <h2 class="govuk-heading-m">{{ 'account.pages.yourProofOfId.summaryListTitle' | translate }}</h2>
+  {{ govukTable({
+    firstCellIsHeader: true,
+    classes: "accounts-table",
+    rows: [
+      [
+        {
+          text: "Thing",
+          classes: "govuk-!-width-one-half"
+        },
+        {
+          text: 'account.pages.yourProofOfId.savedOn' | translate | replace("[date]", "01 January 2022")
+        }
+      ],
+      [
+        {
+          text: "Thing2",
+          classes: "govuk-!-width-one-half"
+        },
+        {
+          text: 'account.pages.yourProofOfId.savedOn' | translate | replace("[date]", "02 January 2022")
+        }
+      ]
+    ]
+  }) }}
+
+  <a href="/account/settings/your-proof-of-identity/delete" class="govuk-link govuk-body">{{ 'account.pages.yourProofOfId.deleteInformationLink' | translate }}</a>
+{% endblock %}

--- a/src/views/index.njk
+++ b/src/views/index.njk
@@ -2,9 +2,12 @@
 {% set pageTitleName = 'Hello world' %}
 {% set serviceName = 'GOV.UK account' %}
 
-
 {% block content %}
 <h1 class="govuk-heading-xl">Hello world</h1>
+  <h2 class="govuk-heading-m">Account</h2>
+  <ul>
+    <li><a href="/account" class="govuk-link">GOV.UK Account</a></li>
+  </ul>
   <h2 class="govuk-heading-m">Identity</h2>
   <ul>
     <li><a href="/identity/prove-identity-logged-out" class="govuk-link">Prove your identity to continue</a></li>
@@ -24,5 +27,4 @@
     <li><a href="/identity/save" class="govuk-link">You’ve successfully proved your identity</a></li>
     <li><a href="/identity/complete/saved" class="govuk-link">You’ve saved your proof of identity to your GOV.UK account</a></li>
   </ul>
-
 {% endblock %}

--- a/src/views/layouts/account.njk
+++ b/src/views/layouts/account.njk
@@ -1,0 +1,31 @@
+{% extends "layouts/base.njk" %}
+{% set serviceName = 'account.serviceName' | translate %}
+
+{% block header %}
+  {% if hideSignOutLink %}
+    {{ govukHeader({
+         homepageUrl: '/'
+     }) }}
+  {% else %}
+    {{ govukHeader({
+       homepageUrl: '/',
+       navigationClasses: "govuk-header__navigation--end",
+       navigation: [
+           {
+             href: '/account',
+             text: 'account.header.accountLink' | translate,
+             active: true if activeNavLink == '/account'
+           },
+           {
+             href: '/account/settings',
+             text: 'account.header.accountSettingsLink' | translate,
+             active: true if activeNavLink == '/account/settings'
+           },
+           {
+               href: "/sign-out",
+               text: 'account.header.signOutLink' | translate
+           }
+         ]
+    })}}
+  {% endif %}
+{% endblock %}

--- a/src/views/layouts/base.njk
+++ b/src/views/layouts/base.njk
@@ -19,17 +19,17 @@
 {% endblock %}
 
 {% block pageTitle %}
-    {% if error or errors %}
-        {{ 'general.errorTitlePrefix' | translate }}
-        -
-    {% endif %}
-    {% if pageTitleName %}
-        {{ pageTitleName }}
-        -
-    {% endif %}
-    {% if serviceName %}
-      {{ serviceName }}
-    {% endif %}
+  {% if error or errors %}
+      {{ 'general.errorTitlePrefix' | translate }}
+      -
+  {% endif %}
+  {% if pageTitleName %}
+      {{ pageTitleName }}
+      -
+  {% endif %}
+  {% if serviceName %}
+    {{ serviceName }}
+  {% endif %}
 {% endblock %}
 
 {% block main %}
@@ -41,13 +41,13 @@
         html: 'general.phaseBanner.text' | translate | replace ("[supportUrl]", authFrontEndUrl + "/contact-us?supportType=PUBLIC")
     }) }}
     {% if backLink %}
-        <a href="{{backLink}}" class="govuk-back-link">{{'general.back' | translate}}</a>
-     {% endif %}
+      <a href="{{backLink}}" class="govuk-back-link govuk-!-margin-bottom-0">{{'general.back' | translate}}</a>
+    {% endif %}
     {% block beforeContent %}{% endblock %}
     <main class="govuk-main-wrapper {{ mainClasses }}" id="main-content">
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds {{ rowClasses }}">
-        {% block content %}{% endblock %}
+          {% block content %}{% endblock %}
         </div>
       </div>
     </main>
@@ -55,31 +55,31 @@
 {% endblock %}
 
 {% block footer %}
-    {{ govukFooter({
-        meta: {
-            items: [
-                {
-                    href: "/accessibility-statement",
-                    attributes: { target: "_blank"},
-                    text: 'general.footer.accessibilityStatement.linkText' | translate
-                },
-                {
-                    href: "https://www.gov.uk/help/cookies",
-                    attributes: { target: "_blank"},
-                    text: 'general.footer.cookies.linkText' | translate
-                },
-                {
-                    href: "/terms-and-conditions",
-                    attributes: { target: "_blank"},
-                    text: 'general.footer.terms.linkText' | translate
-                },
-                {
-                    href: "/privacy-notice",
-                    attributes: { target: "_blank"},
-                    text: 'general.footer.privacy.linkText' | translate
-                }
-            ]
-        }
+  {{ govukFooter({
+      meta: {
+        items: [
+          {
+              href: "/accessibility-statement",
+              attributes: { target: "_blank"},
+              text: 'general.footer.accessibilityStatement.linkText' | translate
+          },
+          {
+              href: "https://www.gov.uk/help/cookies",
+              attributes: { target: "_blank"},
+              text: 'general.footer.cookies.linkText' | translate
+          },
+          {
+              href: "/terms-and-conditions",
+              attributes: { target: "_blank"},
+              text: 'general.footer.terms.linkText' | translate
+          },
+          {
+              href: "/privacy-notice",
+              attributes: { target: "_blank"},
+              text: 'general.footer.privacy.linkText' | translate
+          }
+        ]
+      }
     }) }}
 {% endblock %}
 


### PR DESCRIPTION
Build static frontend templates and views of the account dashboard and
account subpages as illustrated in the [Figma prototype](https://www.figma.com/file/f6Kn3ZhjCiiJSIQpNFt7On/Solid-example-flows?node-id=966%3A2514).

These views are the basis for the user's dashboard where they can
view their data. Currently the data is hard coded, but the intention is
that the dashboard will interact with the user's solid pod and display
their identity attributes, communication preferences and existing access
grants.