### PR TITLE
Add multilingual support from Linked Data vocabs

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,9 @@
 dist
 node_modules
 infrastructure
+
+#
+# No need to lint generated code (as its never going to conform to
+# "everyone's" linting rules, since they'll always be so subjective).
+#
+src/InruptTooling

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,22 @@
+# Ignore folder used to install vocabs from remote repositories (for when we
+# wish to work a lot with terms in those vocabs). Having those vocabs locally
+# means we can use the Artifact Generator to 'watch' them, and therefore
+# automatically re-generate the corresponding source-code when we make edits
+# to the local vocab copies (meaning developers can use new or changed terms
+# immediately in their main code).
+# (Of course, we need to remember to create PRs to the upstream repository
+# when we're done!). We can also store here locally generated artifacts from
+# local vocabs that we don't yet want to publish anywhere public yet.
+src/InruptTooling/Vocab
+
+# Ignore any generated script files that allow quick re-watching of bundles of
+# vocabs.
+watch-*.sh
+
+# If we run the Artifact Generator locally, then by default it will generate
+# to this directory, so ignore it, just as a precaution.
+Generated
+
 # Logs
 logs
 *.log

--- a/README.md
+++ b/README.md
@@ -2,6 +2,43 @@
 
 A prototype to evaluate Solid as a personal data store
 
+## Pre-requisite - generate code from GDS vocabularies
+
+Since we may not yet wish to publicly publish any of the vocabularies we
+develop for this Proof of Concept (namely our own internal vocabularies, or ones
+we create on behalf of 3rd-party data sources that don't yet provide Linked Data
+vocabularies themselves), we first need to generate a local `npm` package that
+bundles together JavaScript classes representing all the terms from all the
+vocabularies we wish to use or reference in our code.
+
+To do this, we run Inrupt's open-source
+[Artifact Generator](https://github.com/inrupt/artifact-generator), pointing
+it at our local configuration YAML file that references all the local
+vocabularies we wish to use terms from, and that bundles together the
+generated JavaScript classes that contain constants for all the terms from
+each of those vocabularies (which are all located in the
+[./src/vocab](./src/vocab) directory):
+
+```script
+npx @inrupt/artifact-generator generate --vocabListFile "src/vocab/vocab-gds-poc-bundle-all.yml" --outputDirectory "./src/InruptTooling/Vocab/GdsPoc" --noPrompt --force --publish npmInstallAndBuild
+```
+
+**Note:** If you have the Artifact Generator installed locally (e.g., for
+faster execution), then you can run it directly:
+
+```script
+node ../SDK/artifact-generator/src/index.js generate --vocabListFile "src/vocab/vocab-gds-poc-bundle-all.yml" --outputDirectory "./src/InruptTooling/Vocab/GdsPoc" --noPrompt --force --publish npmInstallAndBuild
+```
+
+**Note**: during any ETL development, it's generally very common to continue
+to re-run the Artifact Generator regularly, for example after any local
+vocabulary changes or updates (we can also run it in 'file watcher' mode so
+that it runs automatically on any local vocab file changes, which is really
+convenient). So since it's a such a regular thing to run, it's generally a
+good idea to clone and run the Artifact Generator locally (as that's much
+faster than using `npx`).
+
+
 ## Running the prototype app
 
 1. Run `npm ci` to install dependencies

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@inrupt/solid-client": "^1.23.1",
         "@inrupt/solid-client-authn-node": "^1.12.1",
-        "@inrupt/vocab-common-rdf": "^1.0.5",
+        "@inrupt/vocab-gds-poc-bundle-all-solidcommonvocab": "file:./src/InruptTooling/Vocab/GdsPoc/Generated/SourceCodeArtifacts/TypeScript-SolidCommonVocab",
         "cookie-parser": "~1.4.4",
         "cookie-session": "^2.0.0",
         "debug": "~4.3.4",
@@ -173,14 +173,16 @@
       }
     },
     "node_modules/@inrupt/solid-common-vocab": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-common-vocab/-/solid-common-vocab-1.0.0.tgz",
-      "integrity": "sha512-LcImhJqqPsNl/OlULzEEK2rYevty0eh1zaOLVz3lnydEU1DQkeaJ8fKBxKdp5/QjCtnIYcaDjh5U11PGh29Dgg=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-common-vocab/-/solid-common-vocab-1.0.1.tgz",
+      "integrity": "sha512-daCb8amQHzfB9N5bop3enur6l6UHjt9/fxvC8Or9wdzybAGMSF7UcrW3Pr/MM5H0GOKrVBczlxR4t6sMWgul1g==",
+      "dependencies": {
+        "@rdfjs/types": "^1.1.0"
+      }
     },
-    "node_modules/@inrupt/vocab-common-rdf": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@inrupt/vocab-common-rdf/-/vocab-common-rdf-1.0.5.tgz",
-      "integrity": "sha512-onrehQte8m0XW83WwM6T4o5WgmYGzdYUCef6FDjMKfQCF64FnARFNn5fYhKodimBaAOFKhuJ3vw1NBZV/EYqJw=="
+    "node_modules/@inrupt/vocab-gds-poc-bundle-all-solidcommonvocab": {
+      "resolved": "src/InruptTooling/Vocab/GdsPoc/Generated/SourceCodeArtifacts/TypeScript-SolidCommonVocab",
+      "link": true
     },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.0.8",
@@ -3201,6 +3203,14 @@
         "node": ">=12"
       }
     },
+    "node_modules/rdf-data-factory": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-1.1.1.tgz",
+      "integrity": "sha512-0HoLx7lbBlNd2YTmNKin0txgiYmAV56eVU823at8cG2+iD0Ia5kcRNDpzZy6I/HCtFTymHvTfdhHTzm3ak3Jpw==",
+      "dependencies": {
+        "@rdfjs/types": "*"
+      }
+    },
     "node_modules/rdf-js": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/rdf-js/-/rdf-js-4.0.2.tgz",
@@ -4021,6 +4031,19 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "src/InruptTooling/Vocab/GdsPoc/Generated/SourceCodeArtifacts/TypeScript-SolidCommonVocab": {
+      "name": "@inrupt/vocab-etl-tutorial-bundle-all-solidcommonvocab",
+      "version": "1.0.1",
+      "license": "Proprietary",
+      "dependencies": {
+        "@inrupt/solid-common-vocab": "^1.0.1",
+        "@rdfjs/types": "^1.1.0",
+        "rdf-data-factory": "^1.1.1"
+      },
+      "devDependencies": {
+        "typescript": "^4.7.4"
+      }
     }
   },
   "dependencies": {
@@ -4128,14 +4151,21 @@
       }
     },
     "@inrupt/solid-common-vocab": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-common-vocab/-/solid-common-vocab-1.0.0.tgz",
-      "integrity": "sha512-LcImhJqqPsNl/OlULzEEK2rYevty0eh1zaOLVz3lnydEU1DQkeaJ8fKBxKdp5/QjCtnIYcaDjh5U11PGh29Dgg=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-common-vocab/-/solid-common-vocab-1.0.1.tgz",
+      "integrity": "sha512-daCb8amQHzfB9N5bop3enur6l6UHjt9/fxvC8Or9wdzybAGMSF7UcrW3Pr/MM5H0GOKrVBczlxR4t6sMWgul1g==",
+      "requires": {
+        "@rdfjs/types": "^1.1.0"
+      }
     },
-    "@inrupt/vocab-common-rdf": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@inrupt/vocab-common-rdf/-/vocab-common-rdf-1.0.5.tgz",
-      "integrity": "sha512-onrehQte8m0XW83WwM6T4o5WgmYGzdYUCef6FDjMKfQCF64FnARFNn5fYhKodimBaAOFKhuJ3vw1NBZV/EYqJw=="
+    "@inrupt/vocab-gds-poc-bundle-all-solidcommonvocab": {
+      "version": "file:src/InruptTooling/Vocab/GdsPoc/Generated/SourceCodeArtifacts/TypeScript-SolidCommonVocab",
+      "requires": {
+        "@inrupt/solid-common-vocab": "^1.0.1",
+        "@rdfjs/types": "^1.1.0",
+        "rdf-data-factory": "^1.1.1",
+        "typescript": "^4.7.4"
+      }
     },
     "@jridgewell/resolve-uri": {
       "version": "3.0.8",
@@ -6397,6 +6427,14 @@
       "integrity": "sha512-LXRkhab1QaPJnhUIt1gtXXKswQCZ9zpflsSZFczG7mCLAkMvVjdqCGk9VXCUss0aOUeEyV2jtFxGcdX8DSkj9w==",
       "requires": {
         "setimmediate": "^1.0.5"
+      }
+    },
+    "rdf-data-factory": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-1.1.1.tgz",
+      "integrity": "sha512-0HoLx7lbBlNd2YTmNKin0txgiYmAV56eVU823at8cG2+iD0Ia5kcRNDpzZy6I/HCtFTymHvTfdhHTzm3ak3Jpw==",
+      "requires": {
+        "@rdfjs/types": "*"
       }
     },
     "rdf-js": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@inrupt/solid-client": "^1.23.1",
     "@inrupt/solid-client-authn-node": "^1.12.1",
-    "@inrupt/vocab-common-rdf": "^1.0.5",
+    "@inrupt/vocab-gds-poc-bundle-all-solidcommonvocab": "file:./src/InruptTooling/Vocab/GdsPoc/Generated/SourceCodeArtifacts/TypeScript-SolidCommonVocab",
     "cookie-parser": "~1.4.4",
     "cookie-session": "^2.0.0",
     "debug": "~4.3.4",

--- a/src/controllers/access.ts
+++ b/src/controllers/access.ts
@@ -15,7 +15,7 @@ import {
   Thing,
   getDatetime,
 } from "@inrupt/solid-client";
-import { RDF, DCTERMS } from "@inrupt/vocab-common-rdf";
+import { RDF, DCTERMS, GDS_POC_MESSAGE } from "@inrupt/vocab-gds-poc-bundle-all-solidcommonvocab";
 
 import { SessionError } from "../errors";
 
@@ -29,9 +29,9 @@ export async function accessGet(req: Request, res: Response): Promise<void> {
       const dataset = await getSolidDataset(datasetUri, {fetch: session.fetch});
       const created = getDatetime(getThing(dataset, datasetUri) as Thing, DCTERMS.created);
 
-      res.render('access/show', {created: created})      
+      res.render('access/show', { GDS_POC_MESSAGE, created })
     } catch (fetchError) {
-      res.render('access/show')
+      res.render('access/show', { GDS_POC_MESSAGE })
     }
   }
 }

--- a/src/controllers/identity/save.ts
+++ b/src/controllers/identity/save.ts
@@ -17,7 +17,7 @@ import {
 
 import { SessionError } from "../../errors";
 
-import { RDF } from "@inrupt/vocab-common-rdf";
+import { RDF } from "@inrupt/vocab-gds-poc-bundle-all-solidcommonvocab";
 // We need to explicitly import the Node.js implementation of 'Blob' here
 // because it's not a global in Node.js (whereas it is global in the browser).
 // We may also need to explicitly convert our usage of 'Blob' into a Buffer

--- a/src/controllers/login.ts
+++ b/src/controllers/login.ts
@@ -4,8 +4,24 @@ import { getSessionFromStorage, Session } from "@inrupt/solid-client-authn-node"
 import { getHostname, getClientId, getEssServiceURI, EssServices } from "../config";
 import { createProfileAndPod } from "../lib/pod";
 
+
+import { GDS_POC_MESSAGE, getLocalStore, CONTEXT_KEY_LOCALE } from "@inrupt/vocab-gds-poc-bundle-all-solidcommonvocab";
+
+// Super-simple list of supported languages (i.e., translations for messages
+// we have provided in our GDS-PoC-specific messages vocabulary).
+const supportedLanguages = [ "en", "cy", "es" ];
+
+// Super-simple way of iterating over and choosing the 'current' language we
+// wish our messages to be presented to the user - i.e., literally just hit
+// <Ctrl-R> to refresh the screen will iterate to the 'next supported
+// language'...
+let langToggleOnRefresh = 0;
+
 export async function loginGet(req: Request, res: Response): Promise<void> {
-  res.render('login/start');
+  const langTag = supportedLanguages[langToggleOnRefresh++ % supportedLanguages.length];
+  getLocalStore().setItem(CONTEXT_KEY_LOCALE, langTag);
+
+  res.render('login/start', { GDS_POC_MESSAGE, langTag });
 }
 
 export async function loginPost(req: Request, res: Response): Promise<void> {
@@ -31,6 +47,6 @@ export async function callbackGet(req: Request, res: Response): Promise<void> {
     if (response.status == 404) {
       await createProfileAndPod(session)
     }
-    res.render('login/success', {webId: session.info.webId})
+    res.render('login/success', { GDS_POC_MESSAGE, webId: session.info.webId })
   }
 }

--- a/src/views/access/show.njk
+++ b/src/views/access/show.njk
@@ -19,12 +19,12 @@
 {% endblock %}
 
 {% block content %}
-  <h1 class="govuk-heading-xl">Access logs</h1>
+  <h1 class="govuk-heading-xl">{{ GDS_POC_MESSAGE.msgAccessLogs.message }}</h1>
 
   {% if created %}
-    <p class="govuk-body">Last event at: {{ created }}</p>
+    <p class="govuk-body">{{ GDS_POC_MESSAGE.msgAuditLastEventTimestamp.messageParams(created) }}</p>
   {% else %}
-    <p class="govuk-body">No previous events found</p>
+    <p class="govuk-body">{{ GDS_POC_MESSAGE.msgAuditLastEventNone.message }}</p>
   {% endif %}
 
   <form action="/access-logs" method="post">

--- a/src/views/login/start.njk
+++ b/src/views/login/start.njk
@@ -2,7 +2,7 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% block content %}
-  <h1 class="govuk-heading-xl">Welcome to the GDS Solid PoC!</h1>
+  <h1 class="govuk-heading-xl">{{ GDS_POC_MESSAGE.msgWelcome.message }} [{{langTag}}]</h1>
 
   <form action="/login" method="post">
     {{ govukButton({

--- a/src/views/login/success.njk
+++ b/src/views/login/success.njk
@@ -19,7 +19,14 @@
 {% endblock %}
 
 {% block content %}
-  <p class="govuk-body">Logged in with the WebID: [{{ webId }}].</p>
+  <!--
+     Now we can use vocabularies to define our messages (with lots of extra
+     metadata, including translations of descriptions, and references to
+     'seeAlso' more information, etc.), instead of hard-coding text in just
+     one language...
+     <p class="govuk-body">Logged in with the WebID: [{{ webId }}].</p>
+   -->
+  <p class="govuk-body">{{GDS_POC_MESSAGE.msgLoggedInAsWebId.messageParams(webId)}}</p>
 
   <p class="govuk-body">
     {{ govukButton({

--- a/src/vocab/GovUk-Gds/CopyOfVocab/gov-uk-gds-poc-message.ttl
+++ b/src/vocab/GovUk-Gds/CopyOfVocab/gov-uk-gds-poc-message.ttl
@@ -1,0 +1,73 @@
+prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+prefix xsd: <http://www.w3.org/2001/XMLSchema#>
+prefix owl: <http://www.w3.org/2002/07/owl#>
+prefix vann: <http://purl.org/vocab/vann/>
+prefix dcterms: <http://purl.org/dc/terms/>
+prefix cc: <http://creativecommons.org/ns#>
+prefix skos: <http://www.w3.org/2004/02/skos/core#>
+prefix skosxl: <http://www.w3.org/2008/05/skos-xl#>
+
+prefix inrupt_gen: <https://inrupt.com/vocab/tool/artifact_generator#>
+prefix inrupt_common: <https://inrupt.com/vocab/common#>
+
+prefix gov_uk_gds_poc: <https://vocab.gov.uk/gds/poc/>
+
+#
+# This vocabulary is use to define terms that are specific to our particular
+# application - in this case, the GDS Proof of Concept (PoC).
+#
+
+#
+# Describe our vocabulary - i.e., an English description, its version, who created it, its
+# suggested prefix, its license, etc.
+#
+<https://vocab.gov.uk/gds/poc/v/gdsMessage> a owl:Ontology, inrupt_gen:Ontology  ;
+     owl:versionInfo "0.0.1" ;
+     owl:versionIRI <https://vocab.gov.uk/gds/poc/0.0.1> ;
+     dcterms:title "Vocabulary for Inrupt's ETL Tutorial" ;
+     dcterms:description """A vocabulary for messages used across the GDS Proof of Concept"""@en ;
+     dcterms:creator <https://id.gov.uk/webid/dept/gds> ;
+     dcterms:issued "2021-08-23"^^xsd:date ;
+     vann:preferredNamespacePrefix "gds_poc_message" ;
+     vann:preferredNamespaceUri <https://vocab.gov.uk/gds/poc/> ;
+     cc:attributionURL gov_uk_gds_poc: ;
+     cc:license <https://creativecommons.org/publicdomain/zero/1.0/> .
+
+
+ gov_uk_gds_poc:msgWelcome a rdfs:Literal ;
+    skos:definition "Welcome to the GDS Proof of Concept application!"@en ;
+    skos:definition "Croeso i gais Prawf Cysyniad GDS!"@cy ;
+    skos:definition "¡Bienvenido a la aplicación de prueba de concepto de GDS!"@es .
+
+gov_uk_gds_poc:msgLoggedInAsWebId a rdfs:Literal ;
+    skos:definition "Logged in with the WebID: [{{0}}]."@en ;
+    skos:definition "Wedi mewngofnodi gyda'r WebID: [{{0}}]."@cy ;
+    skos:definition "Inicie sesión con el WebID: [{{0}}]."@es .
+
+gov_uk_gds_poc:msgAuditLastEventTimestamp a rdfs:Literal ;
+    skos:definition "Last event at: [{{0}}]."@en ;
+    skos:definition "Digwyddiad diwethaf yn: [{{0}}]."@cy ;
+    skos:definition "Último evento en: [{{0}}]."@es .
+
+gov_uk_gds_poc:msgAuditLastEventNone a rdfs:Literal ;
+    skos:definition "No previous events found."@en ;
+    skos:definition "Ni chanfuwyd unrhyw ddigwyddiadau blaenorol."@cy ;
+    skos:definition "No se encontraron eventos anteriores."@es .
+
+gov_uk_gds_poc:msgAccessLogs a rdfs:Literal ;
+    skos:definition "Access logs"@en ;
+    skos:definition "Logiau mynediad"@cy ;
+    skos:definition "Registros de acceso"@es .
+
+
+
+#
+#gov_uk_gds_poc: a rdf:Property, owl:ObjectProperty ;
+#    rdfs:isDefinedBy gov_uk_gds_poc: ;
+#    rdfs:label ""@en ;
+#    rdfs:label ""@cy ;
+#    rdfs:label ""@es ;
+#    rdfs:comment ""@en ;
+#    rdfs:comment ""@cy ;
+#    rdfs:comment ""@es .

--- a/src/vocab/GovUk-Gds/CopyOfVocab/gov-uk-gds-poc.ttl
+++ b/src/vocab/GovUk-Gds/CopyOfVocab/gov-uk-gds-poc.ttl
@@ -1,0 +1,62 @@
+prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+prefix xsd: <http://www.w3.org/2001/XMLSchema#>
+prefix owl: <http://www.w3.org/2002/07/owl#>
+prefix vann: <http://purl.org/vocab/vann/>
+prefix dcterms: <http://purl.org/dc/terms/>
+prefix cc: <http://creativecommons.org/ns#>
+prefix skosxl: <http://www.w3.org/2008/05/skos-xl#>
+
+prefix inrupt_gen: <https://inrupt.com/vocab/tool/artifact_generator#>
+prefix inrupt_common: <https://inrupt.com/vocab/common#>
+
+prefix gov_uk_gds_poc: <https://vocab.gov.uk/gds/poc/>
+
+#
+# This vocabulary is use to define terms that are specific to our particular
+# application - in this case, the GDS Proof of Concept (PoC).
+#
+
+#
+# Describe our vocabulary - i.e., an English description, its version, who created it, its
+# suggested prefix, its license, etc.
+#
+<https://vocab.gov.uk/gds/poc/v/gdsCore> a owl:Ontology, inrupt_gen:Ontology  ;
+     owl:versionInfo "0.0.1" ;
+     owl:versionIRI <https://vocab.gov.uk/gds/poc/0.0.1> ;
+     dcterms:title "Vocabulary for Inrupt's ETL Tutorial" ;
+     dcterms:description """A vocabulary for common terms used across this GDS Proof of Concept"""@en ;
+     dcterms:creator <https://id.gov.uk/webid/dept/gds> ;
+     dcterms:issued "2021-08-23"^^xsd:date ;
+     vann:preferredNamespacePrefix "gov_uk_gds_poc" ;
+     vann:preferredNamespaceUri <https://vocab.gov.uk/gds/poc/> ;
+     cc:attributionURL gov_uk_gds_poc: ;
+     cc:license <https://creativecommons.org/publicdomain/zero/1.0/> .
+
+gov_uk_gds_poc:GdsPoc a rdf:Property, owl:ObjectProperty ;
+    rdfs:isDefinedBy gov_uk_gds_poc: ;
+    rdfs:label "GDS Proof of Concept"@en ;
+    rdfs:label "Prawf o Gysyniad GDS"@cy ;
+    rdfs:label "Prueba de concepto de GDS"@es ;
+    rdfs:comment "GDS Proof of Concept using Inrupt's ESS to provide Solid Pods to demonstrate reusable identities."@en ;
+    rdfs:comment "Prawf Cysyniad GDS gan ddefnyddio ESS Inrupt i ddarparu Podiau Solid i ddangos hunaniaethau y gellir eu hailddefnyddio."@cy ;
+    rdfs:comment "Prueba de concepto de GDS usando ESS de Inrupt para proporcionar Solid Pods para demostrar identidades reutilizables."@es .
+
+gov_uk_gds_poc:gdsPocEntrypoint a rdf:Property, owl:ObjectProperty ;
+    rdfs:isDefinedBy gov_uk_gds_poc: ;
+    rdfs:label "GDS PoC entrypoint"@en ;
+    rdfs:label "Man mynediad PoC GDS"@cy ;
+    rdfs:label "Punto de entrada de GDS PoC"@es ;
+    rdfs:comment "This property references the Pod entrypoint for the GDS PoC application to store its data in a Pod."@en ;
+    rdfs:comment "Mae'r eiddo hwn yn cyfeirio at y pwynt mynediad Pod ar gyfer y cais GDS PoC i storio ei ddata mewn Pod"@cy ;
+    rdfs:comment "Esta propiedad hace referencia al punto de entrada del Pod para que la aplicación GDS PoC almacene sus datos en un Pod."@es .
+
+#
+#gov_uk_gds_poc: a rdf:Property, owl:ObjectProperty ;
+#    rdfs:isDefinedBy gov_uk_gds_poc: ;
+#    rdfs:label ""@en ;
+#    rdfs:label ""@cy ;
+#    rdfs:label ""@es ;
+#    rdfs:comment ""@en ;
+#    rdfs:comment ""@cy ;
+#    rdfs:comment ""@es .

--- a/src/vocab/GovUk-Gds/Extension/schema-inrupt-ext.ttl
+++ b/src/vocab/GovUk-Gds/Extension/schema-inrupt-ext.ttl
@@ -1,0 +1,695 @@
+prefix foaf: <http://xmlns.com/foaf/0.1/>
+prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+prefix xsd: <http://www.w3.org/2001/XMLSchema#>
+prefix owl: <http://www.w3.org/2002/07/owl#>
+prefix dcterms: <http://purl.org/dc/terms/>
+prefix skos: <http://www.w3.org/2004/02/skos/core#>
+prefix ldp: <http://www.w3.org/ns/ldp#>
+prefix vann: <http://purl.org/vocab/vann/>
+prefix sm: <http://www.omg.org/techprocess/ab/SpecificationMetadata/>
+
+prefix schema: <http://schema.org/>
+
+prefix inrupt_gen: <https://inrupt.com/vocab/tool/artifact_generator#>
+prefix schema_inrupt_ext: <https://w3id.org/inrupt/vocab/extension/schema#>
+
+#
+# Extensions deliberately add (i.e., extend) existing terms in existing
+# vocabularies, specifically to add extra features, such as multilingual
+# values for labels and comments.
+#
+# So we very deliberately re-use the underlying vocab's namespace, but use our
+# own prefix to try and differentiate.
+#
+schema_inrupt_ext: a owl:Ontology, inrupt_gen:Ontology ;
+    owl:versionInfo "0.0.1" ;
+    owl:versionIRI <https://inrupt.com/vocab/extension/schema/0.0.1> ;
+    dcterms:creator <https://inrupt.com/profile/card/#us> ;
+    dcterms:issued "2019/06/18"^^xsd:date ;
+    dcterms:title "Inrupt extension adding multilingual meta-data for Schema.org terms" ;
+    dcterms:description """Inrupt extension to Schema.org terms providing
+ multilingual alternative names (i.e., labels) and translations for comments
+ (e.g., for use directly as labels or tool-tips in user interfaces or error
+ messages). This extension very deliberately cherry-picks the individual terms
+ from Schema.org that Inrupt currently deem generally useful for Solid and Solid
+ applications (meaning we can provide a much cleaner, less noisy and smaller
+ bundle size when generating programming language artifacts that provide
+ convenient constants for just these selected terms, rather than including the
+ over 2,500 terms currently defined in Schema.org).""" ;
+    vann:preferredNamespacePrefix "schema_inrupt_ext" ;
+    vann:preferredNamespaceUri "http://schema.org/" ;
+    dcterms:license sm:MITLicense .
+
+
+#
+# We need this term internally when generating source-code artifacts from vocabularies.
+#
+schema:alternateName
+    rdfs:isDefinedBy schema_inrupt_ext: ;
+    schema:alternateName "Alternate Name"@en ;
+    schema:alternateName "Nom alternatif"@fr ;
+    schema:alternateName "Anderer Name"@de ;
+    schema:alternateName "Nombre alternativo"@es ;
+    schema:alternateName "Nome alternativo"@it ;
+    rdfs:comment "An alias for the item."@en ;
+    rdfs:comment "Un alias pour l'article."@fr ;
+    rdfs:comment "Ein Alias für den Artikel."@de ;
+    rdfs:comment "Un alias para el elemento."@es ;
+    rdfs:comment "Un alias per l'elemento."@it .
+
+
+schema:Organization
+    rdfs:isDefinedBy schema_inrupt_ext: ;
+    schema:alternateName "Organization"@en ;
+    schema:alternateName "Organisation"@fr ;
+    schema:alternateName "Organisation"@de ;
+    schema:alternateName "Organización"@es ;
+    schema:alternateName "Organizzazione"@it ;
+    rdfs:comment "Une organisation telle qu'une école, une ONG, une société, un club, etc."@fr ;
+    rdfs:comment "Eine Organisation wie eine Schule, eine NGO, ein Unternehmen, ein Verein usw."@de ;
+    rdfs:comment "Una organización como una escuela, ONG, corporación, club, etc."@es ;
+    rdfs:comment "Un'organizzazione come una scuola, una ONG, una società, un club, ecc."@it .
+
+schema:Person
+    rdfs:isDefinedBy schema_inrupt_ext: ;
+    schema:alternateName "Person"@en ;
+    schema:alternateName "La personne"@fr ;
+    schema:alternateName "Person"@de ;
+    schema:alternateName "Persona"@es ;
+    schema:alternateName "Persona"@it ;
+    rdfs:comment "Une personne (vivante, morte, mort-vivant ou fictive)."@fr ;
+    rdfs:comment "Eine Person (lebendig, tot, untot oder fiktiv)."@de ;
+    rdfs:comment "Una persona (viva, muerta, no muerta o ficticia)."@es ;
+    rdfs:comment "Una persona (viva, morta, non morta o immaginaria)."@it .
+
+
+schema:givenName
+    rdfs:isDefinedBy schema_inrupt_ext: ;
+    schema:alternateName "Given Name"@en ;
+    schema:alternateName "Prénom"@fr ;
+    schema:alternateName "Vorname"@de ;
+    schema:alternateName "Nombre de pila"@es ;
+    schema:alternateName "Nome di battesimo"@it ;
+    rdfs:comment "Prénom. Aux États-Unis, le prénom d’une personne. Ceci peut être utilisé avec familyName au lieu de la propriété name."@fr ;
+    rdfs:comment "Vorname. In den USA der Vorname einer Person. Dies kann zusammen mit familyName anstelle der Eigenschaft name verwendet werden."@de ;
+    rdfs:comment "Nombre de pila. En los EE. UU., El primer nombre de una persona. Esto se puede usar junto con familyName en lugar de la propiedad name."@es ;
+    rdfs:comment "Nome di battesimo. Negli Stati Uniti, il primo nome di una persona. Questo può essere usato insieme a familyName al posto della proprietà name."@it .
+
+schema:familyName a rdf:Property ;
+    rdfs:isDefinedBy schema_inrupt_ext: ;
+    schema:alternateName "Family Name"@en ;
+    schema:alternateName "Nom de famille"@fr ;
+    schema:alternateName "Nachname"@de ;
+    schema:alternateName "Apellido"@es ;
+    schema:alternateName "Cognome"@it ;
+    rdfs:comment "Nom de famille. Aux États-Unis, le nom de famille d’une personne. Ceci peut être utilisé avec GivenName au lieu de la propriété name."@fr ;
+    rdfs:comment "Nachname. In den USA der Nachname einer Person. Dies kann zusammen mit givenName anstelle der Eigenschaft name verwendet werden."@de ;
+    rdfs:comment "Apellido. En los EE.UU., el apellido de una persona. Esto se puede usar junto con givenName en lugar de la propiedad name."@es ;
+    rdfs:comment "Cognome. Negli Stati Uniti, il cognome di una persona. Questo può essere usato insieme a givenName al posto della proprietà name."@it .
+
+schema:birthDate
+    rdfs:isDefinedBy schema_inrupt_ext: ;
+    schema:alternateName "Date of birth"@en ;
+    schema:alternateName "Date de naissance"@fr ;
+    schema:alternateName "Geburtsdatum"@de ;
+    schema:alternateName "Fecha de nacimiento"@es ;
+    schema:alternateName "Data di nascita"@it ;
+    rdfs:comment "Date de naissance."@fr ;
+    rdfs:comment "Geburtsdatum."@de ;
+    rdfs:comment "Fecha de nacimiento."@es ;
+    rdfs:comment "Data di nascita."@it .
+
+schema:gender
+    rdfs:isDefinedBy schema_inrupt_ext: ;
+    schema:alternateName "Gender"@en ;
+    schema:alternateName "Le genre"@fr ;
+    schema:alternateName "Geschlecht"@de ;
+    schema:alternateName "Género"@es ;
+    schema:alternateName "Genere"@it ;
+    rdfs:comment "Genre de quelque chose, généralement une personne, mais peut-être aussi des personnages fictifs, des animaux, etc. Bien que https://schema.org/Male et https://schema.org/Female puissent être utilisés, les chaînes de texte sont également acceptables pour les personnes qui ne s'identifie pas comme un genre binaire. La propriété gender peut également être utilisée dans un sens étendu pour couvrir par ex. le sexe des équipes sportives. Comme pour le genre des individus, nous n'essayons pas d'énumérer toutes les possibilités. Une SportsTeam mixte peut être indiquée avec une valeur textuelle de 'Mixte'."@fr ;
+    rdfs:comment "Geschlecht von etwas, typischerweise eine Person, aber möglicherweise auch fiktive Charaktere, Tiere usw. Während https://schema.org/Male und https://schema.org/Female verwendet werden können, sind Textzeichenfolgen auch für Personen akzeptabel, die nicht als binäres Geschlecht identifizieren. Die Geschlechtseigenschaft kann auch im erweiterten Sinne verwendet werden, um z. das Geschlecht der Sportmannschaften. Wie beim Geschlecht von Personen versuchen wir nicht, alle Möglichkeiten aufzuzählen. Ein gemischtgeschlechtliches SportsTeam kann mit dem Textwert 'Mixed' angegeben werden."@de ;
+    rdfs:comment "Género de algo, generalmente una Persona, pero posiblemente también personajes ficticios, animales, etc. Si bien se pueden usar https://schema.org/Male y https://schema.org/Female, las cadenas de texto también son aceptables para personas que no se identifique como un género binario. La propiedad de género también se puede usar en un sentido amplio para cubrir, p. el género de los equipos deportivos. Al igual que con el género de los individuos, no tratamos de enumerar todas las posibilidades. Un SportsTeam de género mixto se puede indicar con un valor de texto de 'Mixto'."@es ;
+    rdfs:comment "Genere di qualcosa, tipicamente una Persona, ma possibilmente anche personaggi di fantasia, animali, ecc. Sebbene sia possibile utilizzare https://schema.org/Male e https://schema.org/Female, le stringhe di testo sono accettabili anche per le persone che non identificarsi come un genere binario. La proprietà di genere può anche essere utilizzata in senso esteso per coprire ad es. il genere delle squadre sportive. Come per il genere degli individui, non cerchiamo di enumerare tutte le possibilità. Uno SportsTeam di sesso misto può essere indicato con un valore di testo 'Misto'."@it .
+
+schema:additionalName
+    rdfs:isDefinedBy schema_inrupt_ext: ;
+    rdfs:label "additionalName" ;
+    schema:alternateName "Additional Name"@en ;
+    schema:alternateName "Nom additionnel"@fr ;
+    schema:alternateName "Zusätzlicher Name"@de ;
+    schema:alternateName "Nombre adicional"@es ;
+    schema:alternateName "Nome aggiuntivo"@it ;
+    rdfs:comment "Un nom supplémentaire pour une personne peut être utilisé pour un deuxième prénom."@fr ;
+    rdfs:comment "Ein zusätzlicher Name für eine Person kann für einen zweiten Vornamen verwendet werden."@de ;
+    rdfs:comment "Un nombre adicional para una persona, se puede utilizar para un segundo nombre."@es ;
+    rdfs:comment "Un nome aggiuntivo per una persona può essere usato per un secondo nome."@it .
+
+schema:license
+    rdfs:isDefinedBy schema_inrupt_ext: ;
+    schema:alternateName "License"@en ;
+    schema:alternateName "License"@fr ;
+    schema:alternateName "Lizenz"@de ;
+    schema:alternateName "Licencia"@es ;
+    schema:alternateName "Licenza"@it ;
+    rdfs:comment "Un document de licence qui s'applique à ce contenu, généralement indiqué par une URL."@fr ;
+    rdfs:comment "Ein Lizenzdokument, das für diesen Inhalt gilt und in der Regel durch eine URL angegeben wird."@de ;
+    rdfs:comment "Un documento de licencia que se aplica a este contenido, normalmente indicado por URL."@es ;
+    rdfs:comment "Un documento di licenza che si applica a questo contenuto, generalmente indicato dall'URL."@it .
+
+schema:name
+    rdfs:isDefinedBy schema_inrupt_ext: ;
+    schema:alternateName "Name"@en ;
+    schema:alternateName "Nom"@fr ;
+    schema:alternateName "Name"@de ;
+    schema:alternateName "Nombre"@es ;
+    schema:alternateName "Nome"@it ;
+    rdfs:comment "Le nom de l'objet."@fr ;
+    rdfs:comment "Der Name des Artikels."@de ;
+    rdfs:comment "El nombre del artículo."@es ;
+    rdfs:comment "Il nome dell'articolo."@it .
+
+schema:text
+    rdfs:isDefinedBy schema_inrupt_ext: ;
+    schema:alternateName "Text"@en ;
+    schema:alternateName "Texte"@fr ;
+    schema:alternateName "Text"@de ;
+    schema:alternateName "Texto"@es ;
+    schema:alternateName "Testo"@it ;
+    rdfs:comment "Le contenu textuel de ce CreativeWork."@fr ;
+    rdfs:comment "Der Textinhalt dieses CreativeWork."@de ;
+    rdfs:comment "El contenido textual de este CreativeWork."@es ;
+    rdfs:comment "Il contenuto testuale di questo CreativeWork."@it .
+
+schema:identifier
+    rdfs:isDefinedBy schema_inrupt_ext: ;
+    rdfs:seeAlso <https://schema.org/docs/datamodel.html#identifierBg> ;
+    schema:alternateName "Identifer"@en ;
+    schema:alternateName "Identifiant"@fr ;
+    schema:alternateName "Kennung"@de ;
+    schema:alternateName "Identificador"@es ;
+    schema:alternateName "Identificatore"@it ;
+    rdfs:comment "La propriété identifier représente tout type d'identifiant pour tout type de chose, comme les ISBN, les codes GTIN, les UUID, etc. Schema.org fournit des propriétés dédiées pour représenter beaucoup d'entre elles, soit sous forme de chaînes textuelles, soit sous forme de liens URL (URI). Voir les notes de fond pour plus de détails."@fr ;
+    rdfs:comment "Die Bezeichner-Eigenschaft stellt jede Art von Bezeichner für jede Art von Sache dar, z. B. ISBNs, GTIN-Codes, UUIDs usw. Schema.org bietet dedizierte Eigenschaften für die Darstellung vieler dieser Elemente, entweder als Textzeichenfolgen oder als URL-Links (URI). Weitere Informationen finden Sie in den Hintergrundinformationen."@de ;
+    rdfs:comment "La propiedad del identificador representa cualquier tipo de identificador para cualquier tipo de cosa, como ISBN, códigos GTIN, UUID, etc. Schema.org proporciona propiedades dedicadas para representar muchos de estos, ya sea como cadenas textuales o como enlaces URL (URI). Consulte las notas de antecedentes para obtener más detalles."@es ;
+    rdfs:comment "La proprietà identificatore rappresenta qualsiasi tipo di identificatore per qualsiasi tipo di Cosa, come ISBN, codici GTIN, UUID ecc. Schema.org fornisce proprietà dedicate per rappresentare molti di questi, sia come stringhe di testo o come collegamenti URL (URI). Vedere le note di fondo per maggiori dettagli."@it .
+
+schema:description
+    rdfs:isDefinedBy schema_inrupt_ext: ;
+    schema:alternateName "Description"@en ;
+    schema:alternateName "Description"@fr ;
+    schema:alternateName "Beschreibung"@de ;
+    schema:alternateName "Descripción"@es ;
+    schema:alternateName "Descrizione"@it ;
+    rdfs:comment "Une description de l'article."@fr ;
+    rdfs:comment "Eine Beschreibung des Artikels."@de ;
+    rdfs:comment "Una descripción del artículo."@es ;
+    rdfs:comment "Una descrizione dell'articolo."@it .
+
+schema:ImageObject
+    rdfs:isDefinedBy schema_inrupt_ext: ;
+    schema:alternateName "Image"@en ;
+    schema:alternateName "Image"@fr ;
+    schema:alternateName "Bild"@de ;
+    schema:alternateName "Imagen"@es ;
+    schema:alternateName "Immagine"@it ;
+    rdfs:comment "Un fichier image."@fr ;
+    rdfs:comment "Eine Bilddatei."@de ;
+    rdfs:comment "Un archivo de imagen."@es ;
+    rdfs:comment "Un file immagine."@it .
+
+schema:image
+    rdfs:isDefinedBy schema_inrupt_ext: ;
+    rdfs:seeAlso <https://schema.org/ImageObject> ;
+    rdfs:seeAlso <https://schema.org/URL> ;
+    schema:alternateName "Image"@en ;
+    schema:alternateName "Image"@fr ;
+    schema:alternateName "Bild"@de ;
+    schema:alternateName "Imagen"@es ;
+    schema:alternateName "Immagine"@it ;
+    rdfs:comment "Une image de l'article. Cela peut être une URL ou un ImageObject entièrement décrit."@fr ;
+    rdfs:comment "Ein Bild des Artikels. Dies kann eine URL oder ein vollständig beschriebenes ImageObject sein."@de ;
+    rdfs:comment "Una imagen del artículo. Puede ser una URL o un ImageObject completamente descrito."@es ;
+    rdfs:comment "Un'immagine dell'articolo. Può essere un URL o un ImageObject completamente descritto."@it .
+
+schema:url
+    rdfs:isDefinedBy schema_inrupt_ext: ;
+    schema:alternateName "URL"@en ;
+    schema:alternateName "URL"@fr ;
+    schema:alternateName "URL"@de ;
+    schema:alternateName "URL"@es ;
+    schema:alternateName "URL"@it ;
+    rdfs:comment "URL de l'élément."@fr ;
+    rdfs:comment "URL des Artikels."@de ;
+    rdfs:comment "URL del artículo."@es ;
+    rdfs:comment "URL dell'articolo."@it .
+
+schema:URL
+    rdfs:isDefinedBy schema_inrupt_ext: ;
+    schema:alternateName "Datatype URL"@en ;
+    schema:alternateName "URL du type de données"@fr ;
+    schema:alternateName "Datentyp-URL"@de ;
+    schema:alternateName "URL de tipo de datos"@es ;
+    schema:alternateName "URL del tipo di dati"@it ;
+    rdfs:comment "URL du type de données."@fr ;
+    rdfs:comment "Datentyp-URL."@de ;
+    rdfs:comment "URL de tipo de datos."@es ;
+    rdfs:comment "URL del tipo di dati."@it .
+
+schema:startTime
+    rdfs:isDefinedBy schema_inrupt_ext: ;
+    schema:alternateName "Start time"@en ;
+    schema:alternateName "Heure de début"@fr ;
+    schema:alternateName "Startzeit"@de ;
+    schema:alternateName "Hora de inicio"@es ;
+    schema:alternateName "Ora di inizio"@it ;
+    rdfs:comment """L'heure de début de quelque chose. Pour un événement ou un service réservé (par exemple, FoodEstablishmentReservation), l'heure à laquelle il devrait commencer. Pour les actions qui s'étendent sur une période de temps, lorsque l'action a été effectuée. par exemple. John a écrit un livre de janvier à décembre. Pour les médias, y compris l'audio et la vidéo, il s'agit du décalage temporel du début d'un clip dans un fichier plus volumineux.
+
+Notez que Event utilise startDate / endDate au lieu de startTime / endTime, même lors de la description des dates avec des heures. Cette situation pourra être clarifiée dans de futures révisions."""@fr ;
+    rdfs:comment """Die Startzeit von etwas. Für ein reserviertes Ereignis oder eine reservierte Dienstleistung (z. B. FoodEstablishmentReservation) die Zeit, zu der der Start erwartet wird. Für Aktionen, die sich über einen bestimmten Zeitraum erstrecken, als die Aktion ausgeführt wurde. z.B. John schrieb von Januar bis Dezember ein Buch. Bei Medien, einschließlich Audio und Video, ist dies der Zeitversatz des Starts eines Clips in einer größeren Datei.
+
+Beachten Sie, dass Event startDate / endDate anstelle von startTime / endTime verwendet, auch wenn Datumsangaben mit Zeiten beschrieben werden. Diese Situation kann in zukünftigen Überarbeitungen geklärt werden."""@de ;
+    rdfs:comment """La hora de inicio de algo. Para un evento o servicio reservado (por ejemplo, FoodEstablishmentReservation), la hora a la que se espera que comience. Para acciones que abarcan un período de tiempo, cuando se realizó la acción. p.ej. John escribió un libro de enero a diciembre. Para los medios, incluidos el audio y el video, es la diferencia de tiempo del inicio de un clip dentro de un archivo más grande.
+
+Tenga en cuenta que Event usa startDate / endDate en lugar de startTime / endTime, incluso cuando describe fechas con horas. Esta situación puede aclararse en futuras revisiones."""@es ;
+    rdfs:comment """Il tempo di inizio di qualcosa. Per un evento o un servizio riservato (ad esempio FoodEstablishmentReservation), l'ora in cui dovrebbe iniziare. Per azioni che coprono un periodo di tempo, quando l'azione è stata eseguita. per esempio. John ha scritto un libro da gennaio a dicembre. Per i media, inclusi audio e video, è la differenza di tempo dell'inizio di una clip all'interno di un file più grande.
+
+Nota che Event utilizza startDate / endDate invece di startTime / endTime, anche quando descrive le date con gli orari. Questa situazione potrebbe essere chiarita in future revisioni."""@it .
+
+schema:endTime
+    rdfs:isDefinedBy schema_inrupt_ext: ;
+    schema:alternateName "End time"@en ;
+    schema:alternateName "Heure de fin"@fr ;
+    schema:alternateName "Endzeit"@de ;
+    schema:alternateName "Hora de finalización"@es ;
+    schema:alternateName "Tempo scaduto"@it ;
+    rdfs:comment """La fin de quelque chose. Pour un événement ou un service réservé (par exemple, FoodEstablishmentReservation), l'heure à laquelle il devrait se terminer. Pour les actions qui s'étendent sur une période de temps, lorsque l'action a été effectuée. par exemple. John a écrit un livre de janvier à décembre. Pour les médias, y compris l'audio et la vidéo, il s'agit du décalage temporel de la fin d'un clip dans un fichier plus volumineux.
+
+Notez que Event utilise startDate / endDate au lieu de startTime / endTime, même lors de la description des dates avec des heures. Cette situation pourra être clarifiée dans de futures révisions."""@fr ;
+    rdfs:comment """Die Endzeit von etwas. Für ein reserviertes Ereignis oder eine reservierte Dienstleistung (z. B. FoodEstablishmentReservation) die Zeit, die voraussichtlich endet. Für Aktionen, die sich über einen bestimmten Zeitraum erstrecken, als die Aktion ausgeführt wurde. z.B. John schrieb von Januar bis Dezember ein Buch. Bei Medien, einschließlich Audio und Video, ist dies der Zeitversatz des Endes eines Clips in einer größeren Datei.
+
+Beachten Sie, dass Event startDate / endDate anstelle von startTime / endTime verwendet, auch wenn Datumsangaben mit Zeiten beschrieben werden. Diese Situation kann in zukünftigen Überarbeitungen geklärt werden."""@de ;
+    rdfs:comment """El tiempo final de algo. Para un evento o servicio reservado (por ejemplo, FoodEstablishmentReservation), la hora a la que se espera que finalice. Para acciones que abarcan un período de tiempo, cuando se realizó la acción. p.ej. John escribió un libro de enero a diciembre. En el caso de los medios, incluidos el audio y el video, es la diferencia de tiempo del final de un clip dentro de un archivo más grande.
+
+Tenga en cuenta que Event usa startDate / endDate en lugar de startTime / endTime, incluso cuando describe fechas con horas. Esta situación puede aclararse en futuras revisiones."""@es ;
+    rdfs:comment """L'ora della fine di qualcosa. Per un evento o un servizio riservato (ad esempio, FoodEstablishmentReservation), il tempo previsto per la fine. Per azioni che coprono un periodo di tempo, quando l'azione è stata eseguita. per esempio. John ha scritto un libro da gennaio a dicembre. Per i media, inclusi audio e video, è lo sfasamento temporale della fine di una clip all'interno di un file più grande.
+
+Nota che Event utilizza startDate / endDate invece di startTime / endTime, anche quando descrive le date con gli orari. Questa situazione potrebbe essere chiarita in future revisioni."""@it .
+
+schema:startDate
+    rdfs:isDefinedBy schema_inrupt_ext: ;
+    schema:alternateName "Start date"@en ;
+    schema:alternateName "Date de début"@fr ;
+    schema:alternateName "Anfangsdatum"@de ;
+    schema:alternateName "Fecha de inicio"@es ;
+    schema:alternateName "Data d'inizio"@it ;
+    rdfs:comment "La date et l'heure de début de l'élément (au format de date ISO 8601)."@fr ;
+    rdfs:comment "Das Startdatum und die Startzeit des Elements (im ISO 8601-Datumsformat)."@de ;
+    rdfs:comment "La fecha y hora de inicio del artículo (en formato de fecha ISO 8601)."@es ;
+    rdfs:comment "La data e l'ora di inizio dell'articolo (in formato data ISO 8601)."@it .
+
+schema:endDate
+    rdfs:isDefinedBy schema_inrupt_ext: ;
+    schema:alternateName "End date"@en ;
+    schema:alternateName "Date de fin"@fr ;
+    schema:alternateName "Endtermin"@de ;
+    schema:alternateName "Fecha final"@es ;
+    schema:alternateName "Data di fine"@it ;
+    rdfs:comment "La date et l'heure de fin de l'article (au format de date ISO 8601)."@fr ;
+    rdfs:comment "Das Enddatum und die Endzeit des Elements (im ISO 8601-Datumsformat)."@de ;
+    rdfs:comment "La fecha y hora de finalización del artículo (en formato de fecha ISO 8601)."@es ;
+    rdfs:comment "La data e l'ora di fine dell'articolo (in formato data ISO 8601)."@it .
+
+schema:email
+    rdfs:isDefinedBy schema_inrupt_ext: ;
+    schema:alternateName "EMail"@en ;
+    schema:alternateName "E-mail"@fr ;
+    schema:alternateName "EMail"@de ;
+    schema:alternateName "Correo electrónico"@es ;
+    schema:alternateName "E-mail"@it ;
+    rdfs:comment "Adresse e-mail."@fr ;
+    rdfs:comment "E-Mail-Addresse."@de ;
+    rdfs:comment "Dirección de correo electrónico."@es ;
+    rdfs:comment "Indirizzo e-mail."@it .
+
+#
+# Terms added initially to help describe Verifiable Credentials.
+#
+schema:MedicalTherapy
+    rdfs:isDefinedBy schema_inrupt_ext: ;
+    schema:alternateName "Medical therapy"@en ;
+    schema:alternateName "Thérapie médicale"@fr ;
+    schema:alternateName "Medizinische Therapie"@de ;
+    schema:alternateName "Terapia medica"@es ;
+    schema:alternateName "Terapia medica"@it ;
+    rdfs:comment "Toute intervention médicale conçue pour prévenir, traiter et guérir les maladies humaines et les conditions médicales, y compris les thérapies curatives et palliatives. Les thérapies médicales sont généralement des processus de soins reposant sur la pharmacothérapie, la thérapie comportementale, la thérapie de soutien (avec du liquide ou de la nutrition par exemple) ou la désintoxication (par exemple l'hémodialyse) visant à améliorer ou à prévenir un état de santé."@fr ;
+    rdfs:comment "Jede medizinische Intervention zur Vorbeugung, Behandlung und Heilung menschlicher Krankheiten und Erkrankungen, einschließlich kurativer und palliativer Therapien. Medizinische Therapien sind typischerweise Pflegeprozesse, die auf Pharmakotherapie, Verhaltenstherapie, unterstützender Therapie (zum Beispiel mit Flüssigkeit oder Ernährung) oder Entgiftung (z. B. Hämodialyse) beruhen, um einen Gesundheitszustand zu verbessern oder zu verhindern."@de ;
+    rdfs:comment "Cualquier intervención médica diseñada para prevenir, tratar y curar enfermedades y afecciones humanas, incluidas las terapias curativas y paliativas. Las terapias médicas son típicamente procesos de atención que se basan en farmacoterapia, terapia conductual, terapia de apoyo (con líquidos o nutrición, por ejemplo) o desintoxicación (por ejemplo, hemodiálisis) con el objetivo de mejorar o prevenir una condición de salud."@es ;
+    rdfs:comment "Qualsiasi intervento medico progettato per prevenire, trattare e curare malattie e condizioni mediche umane, comprese le terapie curative e palliative. Le terapie mediche sono tipicamente processi di cura che si basano su farmacoterapia, terapia comportamentale, terapia di supporto (con liquidi o nutrizione per esempio) o disintossicazione (ad esempio emodialisi) volti a migliorare o prevenire una condizione di salute."@it .
+
+schema:primaryPrevention
+    rdfs:isDefinedBy schema_inrupt_ext: ;
+    schema:alternateName "Primary prevention"@en ;
+    schema:alternateName "Prévention primaire"@fr ;
+    schema:alternateName "Primärprävention"@de ;
+    schema:alternateName "Prevención primaria"@es ;
+    schema:alternateName "Prevenzione primaria"@it ;
+    rdfs:comment "Une thérapie préventive utilisée pour empêcher une apparition initiale de la condition médicale, telle que la vaccination."@fr ;
+    rdfs:comment "Eine vorbeugende Therapie, die verwendet wird, um ein anfängliches Auftreten des medizinischen Zustands zu verhindern, wie z. B. eine Impfung.."@de ;
+    rdfs:comment "Terapia preventiva que se usa para prevenir la aparición inicial de la afección médica, como la vacunación."@es ;
+    rdfs:comment "Una terapia preventiva utilizzata per prevenire il verificarsi iniziale della condizione medica, come la vaccinazione."@it .
+
+schema:EducationalOccupationalCredential
+    rdfs:isDefinedBy schema_inrupt_ext: ;
+    schema:alternateName "Educational occupational credential"@en ;
+    schema:alternateName "Diplôme professionnel d'études"@fr ;
+    schema:alternateName "Berufsausbildungsnachweis"@de ;
+    schema:alternateName "Credencial educativa ocupacional"@es ;
+    schema:alternateName "Credenziali professionali educative"@it ;
+    rdfs:comment "Un diplôme d'études ou professionnelles. Un diplôme, un diplôme universitaire, une certification, une qualification, un insigne, etc., qui peut être décerné à une personne ou à une autre entité qui répond aux exigences définies par le justificatif."@fr ;
+    rdfs:comment "Ein Bildungs- oder Berufsausweis. Ein Diplom, ein akademischer Abschluss, eine Zertifizierung, eine Qualifikation, ein Abzeichen usw., das an eine Person oder eine andere Einrichtung vergeben werden kann, die die vom Berechtigungsnachweis festgelegten Anforderungen erfüllt."@de ;
+    rdfs:comment "Una credencial educativa u ocupacional. Un diploma, título académico, certificación, calificación, insignia, etc., que se puede otorgar a una persona u otra entidad que cumpla con los requisitos definidos por el credencial."@es ;
+    rdfs:comment "Una credenziale educativa o professionale. Un diploma, titolo accademico, certificazione, qualifica, badge, ecc., Che possono essere rilasciati a una persona o altra entità che soddisfi i requisiti definiti dal credenziale."@it .
+
+schema:qualifications
+    rdfs:isDefinedBy schema_inrupt_ext: ;
+    schema:alternateName "Qualifications"@en ;
+    schema:alternateName "Qualifications"@fr ;
+    schema:alternateName "Qualifikationen"@de ;
+    schema:alternateName "Calificaciones"@es ;
+    schema:alternateName "Titoli di studio"@it ;
+    rdfs:comment "Qualifications spécifiques requises pour ce rôle ou cette profession."@fr ;
+    rdfs:comment "Spezifische Qualifikationen, die für diese Rolle oder diesen Beruf erforderlich sind."@de ;
+    rdfs:comment "Calificaciones específicas requeridas para este rol u ocupación."@es ;
+    rdfs:comment "Qualifiche specifiche richieste per questo ruolo o occupazione."@it .
+
+schema:attendee
+    rdfs:isDefinedBy schema_inrupt_ext: ;
+    schema:alternateName "Attendee"@en ;
+    schema:alternateName "Participante"@fr ;
+    schema:alternateName "Teilnehmerin"@de ;
+    schema:alternateName "Asistente"@es ;
+    schema:alternateName "Partecipante"@it ;
+    rdfs:comment "Une personne ou une organisation participant à l'événement."@fr ;
+    rdfs:comment "Eine Person oder Organisation, die an der Veranstaltung teilnimmt.."@de ;
+    rdfs:comment "Una persona u organización que asista al evento."@es ;
+    rdfs:comment "Una persona o un'organizzazione che partecipa all'evento."@it .
+
+#
+# Address information.
+#
+schema:PostalAddress
+    rdfs:isDefinedBy schema_inrupt_ext: ;
+    schema:alternateName "Postal address"@en ;
+    schema:alternateName "Adresse postale"@fr ;
+    schema:alternateName "Anschrift"@de ;
+    schema:alternateName "Direccion postal"@es ;
+    schema:alternateName "Indirizzo postale"@it ;
+    rdfs:comment "L'adresse postale."@fr ;
+    rdfs:comment "Die Postanschrift."@de ;
+    rdfs:comment "La dirección postal."@es ;
+    rdfs:comment "L'indirizzo di posta."@it .
+
+schema:address
+    rdfs:isDefinedBy schema_inrupt_ext: ;
+    schema:alternateName "Address"@en ;
+    schema:alternateName "Adresse"@fr ;
+    schema:alternateName "Die Anschrift"@de ;
+    schema:alternateName "Dirección"@es ;
+    schema:alternateName "Indirizzo"@it ;
+    rdfs:comment "Adresse physique de l'article."@fr ;
+    rdfs:comment "Physische Adresse des Artikels."@de ;
+    rdfs:comment "Dirección física del artículo."@es ;
+    rdfs:comment "Indirizzo fisico dell'articolo."@it .
+
+schema:streetAddress
+    rdfs:isDefinedBy schema_inrupt_ext: ;
+    schema:alternateName "Street address"@en ;
+    schema:alternateName "Adresse de la rue"@fr ;
+    schema:alternateName "Adresse"@de ;
+    schema:alternateName "Dirección"@es ;
+    schema:alternateName "Indirizzo"@it ;
+    rdfs:comment "L'adresse de la rue. Par exemple, 1600 Amphitheatre Pkwy."@fr ;
+    rdfs:comment "Die Straßenadresse. Zum Beispiel, 1600 Amphitheatre Pkwy."@de ;
+    rdfs:comment "La dirección de la calle. Por ejemplo, 1600 Amphitheatre Pkwy."@es ;
+    rdfs:comment "L'indirizzo stradale. Per esempio, 1600 Amphitheatre Pkwy."@it .
+
+schema:addressLocality
+    rdfs:isDefinedBy schema_inrupt_ext: ;
+    schema:alternateName "Address locality"@en ;
+    schema:alternateName "Adresse localité"@fr ;
+    schema:alternateName "Adresse Ort"@de ;
+    schema:alternateName "Dirección localidad"@es ;
+    schema:alternateName "Indirizzo località"@it ;
+    rdfs:comment "La localité dans laquelle se trouve l'adresse postale et qui se trouve dans la région. Par exemple, vue sur la montagne."@fr ;
+    rdfs:comment "Der Ort, in dem sich die Straßenadresse befindet und der sich in der Region befindet. Zum Beispiel Mountain View."@de ;
+    rdfs:comment "La localidad en la que se encuentra la dirección postal y en la región. Por ejemplo, Mountain View."@es ;
+    rdfs:comment "La località in cui si trova l'indirizzo e che si trova nella regione. Ad esempio, Mountain View."@it .
+
+schema:addressRegion
+    rdfs:isDefinedBy schema_inrupt_ext: ;
+    schema:alternateName "Address region"@en ;
+    schema:alternateName "Région de l'adresse"@fr ;
+    schema:alternateName "Adressregion"@de ;
+    schema:alternateName "Región de dirección"@es ;
+    schema:alternateName "Indirizzo regione"@it ;
+    rdfs:comment "La région dans laquelle se trouve la localité et qui se trouve dans le pays. Par exemple, la Californie ou une autre division administrative de premier niveau appropriée."@fr ;
+    rdfs:comment "Die Region, in der sich der Ort befindet und die sich im Land befindet. Zum Beispiel Kalifornien oder eine andere geeignete Verwaltungseinheit der ersten Ebene."@de ;
+    rdfs:comment "La región en la que se encuentra la localidad y en el país. Por ejemplo, California u otra división administrativa de primer nivel apropiada."@es ;
+    rdfs:comment "La regione in cui si trova la località e che si trova nel paese. Ad esempio, la California o un'altra divisione amministrativa di primo livello appropriata."@it .
+
+schema:postalCode
+    rdfs:isDefinedBy schema_inrupt_ext: ;
+    schema:alternateName "Postal code"@en ;
+    schema:alternateName "Code postal"@fr ;
+    schema:alternateName "Postleitzahl"@de ;
+    schema:alternateName "Código Postal"@es ;
+    schema:alternateName "Codice postale"@it ;
+    rdfs:comment "Le code postal. Par exemple, 94043."@fr ;
+    rdfs:comment "Die Postleitzahl. Beispiel: 94043."@de ;
+    rdfs:comment "El código postal. Por ejemplo, 94043."@es ;
+    rdfs:comment "Il codice postale. Ad esempio, 94043."@it .
+
+schema:addressCountry
+    rdfs:isDefinedBy schema_inrupt_ext: ;
+    schema:alternateName "Address country"@en ;
+    schema:alternateName "Pays de l'adresse"@fr ;
+    schema:alternateName "Adressland"@de ;
+    schema:alternateName "País de la dirección"@es ;
+    schema:alternateName "Indirizzo paese"@it ;
+    rdfs:comment "Le pays. Par exemple, États-Unis. Vous pouvez également fournir le code de pays ISO 3166-1 alpha-2 à deux lettres."@fr ;
+    rdfs:comment "Das Land. Zum Beispiel USA. Sie können auch den zweibuchstabigen ISO 3166-1 Alpha-2-Ländercode angeben."@de ;
+    rdfs:comment "El país. Por ejemplo, EE. UU. También puede proporcionar el código de país ISO 3166-1 alpha-2 de dos letras."@es ;
+    rdfs:comment "Paese. Ad esempio, Stati Uniti. Puoi anche fornire il codice paese ISO 3166-1 alpha-2 di due lettere."@it .
+
+#
+# General terms...
+#
+schema:accessCode
+    rdfs:isDefinedBy schema_inrupt_ext: ;
+    schema:alternateName "Access code"@en ;
+    schema:alternateName "Code d'accès"@fr ;
+    schema:alternateName "Zugangscode"@de ;
+    schema:alternateName "Código de acceso"@es ;
+    schema:alternateName "Codice d'accesso"@it ;
+    rdfs:comment "Mot de passe, code PIN ou code d'accès nécessaire à la livraison (par exemple depuis un casier)."@fr ;
+    rdfs:comment "Passwort, PIN oder Zugangscode, der für die Lieferung benötigt wird (z. B. aus einem Schließfach)."@de ;
+    rdfs:comment "Se necesita contraseña, PIN o código de acceso para la entrega (por ejemplo, de un casillero)."@es ;
+    rdfs:comment "Password, PIN o codice di accesso necessari per la consegna (ad es. da un armadietto)."@it .
+
+schema:accountId
+    rdfs:isDefinedBy schema_inrupt_ext: ;
+    schema:alternateName "Account ID"@en ;
+    schema:alternateName "Identifiant de compte"@fr ;
+    schema:alternateName "Konto-ID"@de ;
+    schema:alternateName "ID de la cuenta"@es ;
+    schema:alternateName "Account ID"@it ;
+    rdfs:comment "L'identifiant du compte sur lequel le paiement sera appliqué."@fr ;
+    rdfs:comment "Die Kennung des Kontos, auf das die Zahlung angewendet wird."@de ;
+    rdfs:comment "El identificador de la cuenta a la que se aplicará el pago."@es ;
+    rdfs:comment "L'identificativo dell'account a cui verrà applicato il pagamento."@it .
+
+schema:serialNumber
+    rdfs:isDefinedBy schema_inrupt_ext: ;
+    schema:alternateName "Serial number"@en ;
+    schema:alternateName "Numéro de série"@fr ;
+    schema:alternateName "Seriennummer"@de ;
+    schema:alternateName "Número de serie"@es ;
+    schema:alternateName "Numero di serie"@it ;
+    rdfs:comment """Le numéro de série ou tout identifiant alphanumérique d'un produit particulier.
+ Lorsqu'il est joint à une offre, il s'agit d'un raccourci pour le numéro de série du produit inclus
+ dans l'offre."""@fr ;
+    rdfs:comment """Die Seriennummer oder eine beliebige alphanumerische Kennung eines bestimmten
+ Produkts. Wenn es einem Angebot beigefügt ist, ist es eine Abkürzung für die Seriennummer des im
+ Angebot enthaltenen Produkts."""@de ;
+    rdfs:comment """El número de serie o cualquier identificador alfanumérico de un producto en
+ particular. Cuando se adjunta a una oferta, es un atajo para el número de serie del producto
+ incluido en la oferta."""@es ;
+    rdfs:comment "."@it .
+
+schema:Product
+    rdfs:isDefinedBy schema_inrupt_ext: ;
+    schema:alternateName "Produit"@fr ;
+    schema:alternateName "Produkt"@de ;
+    schema:alternateName "Producto"@es ;
+    schema:alternateName "Prodotto"@it ;
+    rdfs:comment """Tout produit ou service offert. Par exemple : une paire de chaussures ; un
+ billet de concert ; la location d'une voiture ; une coupe de cheveux; ou un épisode d'une émission
+ télévisée diffusé en ligne."""@fr ;
+    rdfs:comment """Alle angebotenen Produkte oder Dienstleistungen. Zum Beispiel: ein Paar Schuhe;
+ eine Konzertkarte; die Anmietung eines Autos; ein Haarschnitt; oder eine Folge einer online
+ gestreamten Fernsehsendung."""@de ;
+    rdfs:comment """Cualquier producto o servicio ofrecido. Por ejemplo: un par de zapatos; un
+ boleto de concierto; el alquiler de un coche; un corte de pelo o un episodio de un programa de
+ televisión transmitido en línea."""@es ;
+    rdfs:comment """Qualsiasi prodotto o servizio offerto. Ad esempio: un paio di scarpe; un
+ biglietto per il concerto; il noleggio di un'auto; un taglio di capelli; o un episodio di un
+ programma televisivo trasmesso in streaming online."""@it .
+
+schema:productID
+    rdfs:isDefinedBy schema_inrupt_ext: ;
+    schema:alternateName "Product ID"@en ;
+    schema:alternateName "Identifiant du produit"@fr ;
+    schema:alternateName "Produkt ID"@de ;
+    schema:alternateName "Identificación de producto"@es ;
+    schema:alternateName "Numero identificativo del prodotto"@it ;
+    rdfs:comment "L'identifiant du produit, tel que l'ISBN. Par exemple : meta itemprop=\"productID\" content=\"isbn:123-456-789\"."@fr ;
+    rdfs:comment "Die Produktkennung, z. B. ISBN. Beispiel: meta itemprop=\"productID\" content=\"isbn:123-456-789\"."@de ;
+    rdfs:comment "El identificador de producto, como ISBN. Por ejemplo: meta itemprop = \"productID\" content = \"isbn: 123-456-789\"."@es ;
+    rdfs:comment "L'identificatore del prodotto, ad esempio ISBN. Ad esempio: meta itemprop=\"productID\" content=\"isbn:123-456-789\"."@it .
+
+schema:brand
+    rdfs:isDefinedBy schema_inrupt_ext: ;
+    schema:alternateName "Brand"@en ;
+    schema:alternateName "Marque"@fr ;
+    schema:alternateName "Marke"@de ;
+    schema:alternateName "Marca"@es ;
+    schema:alternateName "Marca"@it ;
+    rdfs:comment "La ou les marques associées à un produit ou à un service, ou la ou les marques maintenues par une organisation ou un homme d'affaires."@fr ;
+    rdfs:comment "Die mit einem Produkt oder einer Dienstleistung verbundene(n) Marke(n) oder die Marke(n), die von einer Organisation oder einer Geschäftsperson unterhalten wird."@de ;
+    rdfs:comment "Las marcas asociadas con un producto o servicio, o las marcas mantenidas por una organización o persona de negocios."@es ;
+    rdfs:comment "I marchi associati a un prodotto o servizio o i marchi gestiti da un'organizzazione o da un uomo d'affari."@it .
+
+schema:model
+    rdfs:isDefinedBy schema_inrupt_ext: ;
+    schema:alternateName "Model"@en ;
+    schema:alternateName "Modèle"@fr ;
+    schema:alternateName "Modell"@de ;
+    schema:alternateName "Modelo"@es ;
+    schema:alternateName "Modella"@it ;
+    rdfs:comment "Le modèle du produit. À utiliser avec l'URL d'un ProductModel ou une représentation textuelle de l'identifiant du modèle. L'URL du ProductModel peut provenir d'une source externe. Il est recommandé de fournir en plus des identifiants de produit forts via les propriétés gtin8/gtin13/gtin14 et mpn."@fr ;
+    rdfs:comment "Das Modell des Produkts. Verwendung mit der URL eines Produktmodells oder einer Textdarstellung des Modellbezeichners. Die URL des Produktmodells kann aus einer externen Quelle stammen. Es wird empfohlen, zusätzlich starke Produktkennungen über die Eigenschaften gtin8/gtin13/gtin14 und mpn bereitzustellen."@de ;
+    rdfs:comment "El modelo del producto. Úselo con la URL de un modelo de producto o una representación textual del identificador del modelo. La URL de ProductModel puede provenir de una fuente externa. Se recomienda proporcionar además identificadores de producto sólidos a través de las propiedades gtin8 / gtin13 / gtin14 y mpn."@es ;
+    rdfs:comment "Il modello del prodotto. Utilizzare con l'URL di un ProductModel o una rappresentazione testuale dell'identificatore del modello. L'URL del ProductModel può provenire da una fonte esterna. Si consiglia di fornire anche identificatori di prodotto efficaci tramite le proprietà gtin8/gtin13/gtin14 e mpn."@it .
+
+schema:exifData
+    rdfs:isDefinedBy schema_inrupt_ext: ;
+    schema:alternateName "EXIF data"@en ;
+    schema:alternateName "Données EXIF"@fr ;
+    schema:alternateName "EXIF-Daten"@de ;
+    schema:alternateName "Datos EXIF"@es ;
+    schema:alternateName "Dati EXIF"@it ;
+    rdfs:comment "Données exif pour cet objet."@fr ;
+    rdfs:comment "Exif-Daten für dieses Objekt."@de ;
+    rdfs:comment "Datos exif para este objeto."@es ;
+    rdfs:comment "Dati exif per questo oggetto."@it .
+
+schema:member
+    rdfs:isDefinedBy schema_inrupt_ext: ;
+    schema:alternateName ""@en ;
+    schema:alternateName ""@fr ;
+    schema:alternateName ""@de ;
+    schema:alternateName ""@es ;
+    schema:alternateName ""@it ;
+    rdfs:comment "Membre d'une organisation ou d'un programme. Les organisations peuvent être membres d'organisations ; L'adhésion au programme est généralement réservée aux particuliers."@fr ;
+    rdfs:comment "Ein Mitglied einer Organisation oder einer Programmmitgliedschaft. Organisationen können Mitglieder von Organisationen sein; Die Programmmitgliedschaft ist in der Regel für Einzelpersonen."@de ;
+    rdfs:comment "Un miembro de una Organización o una Membresía del Programa. Las organizaciones pueden ser miembros de organizaciones; La membresía del programa es típicamente para individuos."@es ;
+    rdfs:comment "Un membro di un'organizzazione o un membro del programma. Le organizzazioni possono essere membri di organizzazioni; L'iscrizione al programma è in genere per individui."@it .
+
+schema:Event
+    rdfs:isDefinedBy schema_inrupt_ext: ;
+    schema:alternateName "Event"@en ;
+    schema:alternateName "Événement"@fr ;
+    schema:alternateName "Ereignis"@de ;
+    schema:alternateName "Evento"@es ;
+    schema:alternateName "Evento"@it ;
+    rdfs:comment "Un événement se déroulant à une certaine heure et à un certain endroit, comme un concert, une conférence ou un festival. Des informations sur la billetterie peuvent être ajoutées via l'établissement des offres."@fr ;
+    rdfs:comment "Ein Ereignis, das zu einer bestimmten Zeit und an einem bestimmten Ort stattfindet, z. B. ein Konzert, ein Vortrag oder ein Festival. Ticketing-Informationen können über die Angebotsunterkunft hinzugefügt werden."@de ;
+    rdfs:comment "Un evento que ocurre en un momento y lugar determinados, como un concierto, conferencia o festival. La información de venta de entradas se puede agregar a través de la propiedad de ofertas."@es ;
+    rdfs:comment "Un evento che si svolge in un determinato momento e luogo, ad esempio un concerto, una conferenza o un festival. Le informazioni sulla bigliettazione possono essere aggiunte tramite la struttura delle offerte."@it .
+
+schema:value
+    rdfs:isDefinedBy schema_inrupt_ext: ;
+    schema:alternateName "Value"@en ;
+    schema:alternateName "Valeur"@fr ;
+    schema:alternateName "Wert"@de ;
+    schema:alternateName "Valor"@es ;
+    schema:alternateName "Valore"@it ;
+    rdfs:comment "Valeur de la valeur quantitative ou du nœud de valeur de propriété."@fr ;
+    rdfs:comment "Der Wert des Quantitätswert- oder Eigenschaftswertknotens."@de ;
+    rdfs:comment "Valor del valor cuantitativo o del nodo valor de propiedad."@es ;
+    rdfs:comment "Valore del valore quantitativo o del nodo del valore della proprietà."@it .
+
+schema:distance
+    rdfs:isDefinedBy schema_inrupt_ext: ;
+    schema:alternateName "Distance"@en ;
+    schema:alternateName "Distance"@fr ;
+    schema:alternateName "Abstand"@de ;
+    schema:alternateName "Distancia"@es ;
+    schema:alternateName "Distanza"@it ;
+    rdfs:comment "La distance parcourue, par exemple l'exercice ou le voyage."@fr ;
+    rdfs:comment "Die zurückgelegte Strecke, z.B. Sport treiben oder reisen."@de ;
+    rdfs:comment "La distancia recorrida, por ejemplo, hacer ejercicio o viajar."@es ;
+    rdfs:comment "La distanza percorsa, ad esempio esercitando o viaggiando."@it .
+
+schema:latitude
+    rdfs:isDefinedBy schema_inrupt_ext: ;
+    schema:alternateName "Latitude"@en ;
+    schema:alternateName "Latitude"@fr ;
+    schema:alternateName "Breite"@de ;
+    schema:alternateName "Latitud"@es ;
+    schema:alternateName "Latitudine"@it ;
+    rdfs:comment "Latitude d'un emplacement. Par exemple 37.42242 (WGS 84)."@fr ;
+    rdfs:comment "Der Breitengrad eines Ortes. Beispiel: 37.42242 (WGS 84)."@de ;
+    rdfs:comment "La latitud de un lugar. Por ejemplo, 37.42242 (WGS 84)."@es ;
+    rdfs:comment "Latitudine di una posizione. Ad esempio 37.42242 (WGS 84)."@it .
+
+schema:longitude
+    rdfs:isDefinedBy schema_inrupt_ext: ;
+    schema:alternateName "Longitude"@en ;
+    schema:alternateName "Longitude"@fr ;
+    schema:alternateName "Länge"@de ;
+    schema:alternateName "Longitud"@es ;
+    schema:alternateName "Longitudine"@it ;
+    rdfs:comment "Longitude d'un emplacement. Par exemple -122.08585 (WGS 84)."@fr ;
+    rdfs:comment "Der Längengrad eines Ortes. Beispiel: -122.08585 (WGS 84)."@de ;
+    rdfs:comment "Longitud de una ubicación. Por ejemplo, -122.08585 (WGS 84)."@es ;
+    rdfs:comment "Longitudine di una posizione. Ad esempio -122.08585 (WGS 84)."@it .
+
+schema:dateModified
+    rdfs:isDefinedBy schema_inrupt_ext: ;
+    schema:alternateName "Date modified"@en ;
+    schema:alternateName "Date de modification"@fr ;
+    schema:alternateName "Änderungsdatum"@de ;
+    schema:alternateName "Fecha de modificacion"@es ;
+    schema:alternateName "Data di modifica"@it ;
+    rdfs:comment "Date à laquelle CreativeWork a été modifié le plus récemment ou date à laquelle l'entrée de l'élément a été modifiée dans un DataFeed."@fr ;
+    rdfs:comment "Das Datum, an dem das CreativeWork zuletzt geändert wurde oder wann der Eintrag des Elements in einem DataFeed geändert wurde."@de ;
+    rdfs:comment "La fecha en la que CreativeWork se modificó más recientemente o cuando se modificó la entrada del elemento dentro de un DataFeed."@es ;
+    rdfs:comment "Data in cui CreativeWork è stato modificato più di recente o quando la voce dell'elemento è stata modificata all'interno di un DataFeed."@it .
+
+#
+# Template for pulling in new terms!
+#
+#schema:
+#    rdfs:isDefinedBy schema_inrupt_ext: ;
+#    schema:alternateName ""@en ;
+#    schema:alternateName ""@fr ;
+#    schema:alternateName ""@de ;
+#    schema:alternateName ""@es ;
+#    schema:alternateName ""@it ;
+#    rdfs:comment "."@fr ;
+#    rdfs:comment "."@de ;
+#    rdfs:comment "."@es ;
+#    rdfs:comment "."@it .
+#

--- a/src/vocab/GovUk-Gds/Template/solidCommonVocabDependent/javascript/index.hbs
+++ b/src/vocab/GovUk-Gds/Template/solidCommonVocabDependent/javascript/index.hbs
@@ -1,0 +1,12 @@
+{{#if license/header}}
+{{license/header}}
+
+{{/if}}{{#each generatedVocabs}}
+export { default as {{vocabNameUpperCase}} } from "./GeneratedVocab/{{vocabNameUpperCase}}";
+{{/each}}
+
+export {
+  getLocalStore,
+  CONTEXT_KEY_LOCALE,
+  CONTEXT_KEY_PREFERRED_FALLBACK_LANGUAGE
+} from "@inrupt/solid-common-vocab";

--- a/src/vocab/LICENSE
+++ b/src/vocab/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 Inrupt
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/vocab/LICENSE_HEADER.js
+++ b/src/vocab/LICENSE_HEADER.js
@@ -1,0 +1,22 @@
+/**
+ * MIT License
+ * 
+ * Copyright 2022 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */

--- a/src/vocab/ThirdParty/CopyOfVocab/inrupt-3rd-party-companies-house-uk.ttl
+++ b/src/vocab/ThirdParty/CopyOfVocab/inrupt-3rd-party-companies-house-uk.ttl
@@ -1,0 +1,105 @@
+prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+prefix xsd: <http://www.w3.org/2001/XMLSchema#>
+prefix owl: <http://www.w3.org/2002/07/owl#>
+prefix vann: <http://purl.org/vocab/vann/>
+prefix dcterms: <http://purl.org/dc/terms/>
+prefix cc: <http://creativecommons.org/ns#>
+prefix skos: <http://www.w3.org/2004/02/skos/core#>
+prefix skosxl: <http://www.w3.org/2008/05/skos-xl#>
+prefix schema: <http://schema.org/>
+
+prefix inrupt_gen: <https://inrupt.com/vocab/tool/artifact_generator#>
+prefix inrupt_common: <https://inrupt.com/vocab/common#>
+
+prefix inrupt_3rd_party_companies_house_uk: <https://inrupt.com/vocab/3rdparty/companies-house-uk#>
+
+#
+# Describe our vocabulary - i.e., an English description, its version, who created it, its
+# suggested prefix, its license, etc.
+#
+inrupt_3rd_party_companies_house_uk: a owl:Ontology, inrupt_gen:Ontology  ;
+     owl:versionInfo "0.0.1" ;
+     owl:versionIRI <https://inrupt.com/vocab/3rdparty/companies-house-uk/0.0.1> ;
+     dcterms:title
+         "Inrupt vocabulary for Companies House UK"@en ,
+         "Vocabulario de Inrupt para Companies House UK"@es ;
+     dcterms:description
+         "Inrupt vocabulary created to represent terms from Companies House UK."@en ,
+         "Inrupt vocabulario creado para representar términos de Companies House UK."@es ;
+     rdfs:seeAlso <https://developer.company-information.service.gov.uk/> ;
+     dcterms:creator <https://inrupt.com/profile/card/#us> ;
+     dcterms:issued "2021-08-23"^^xsd:date ;
+     vann:preferredNamespacePrefix "inrupt_3rd_party_companies_house_uk" ;
+     vann:preferredNamespaceUri <https://inrupt.com/vocab/3rdparty/companies-house-uk#> ;
+     cc:attributionURL inrupt_3rd_party_companies_house_uk: ;
+     cc:license <https://creativecommons.org/publicdomain/zero/1.0/> .
+
+#
+# Identifier for the corporate entity representing this data source.
+#
+inrupt_3rd_party_companies_house_uk:CompaniesHouseUk a owl:NamedIndividual ;
+    rdfs:isDefinedBy inrupt_3rd_party_companies_house_uk: ;
+    rdfs:seeAlso <https://www.gov.uk/government/organisations/companies-house> ;
+    rdfs:label "Companies House UK"@en ;
+    rdfs:label "Companies House UK"@es ;
+    rdfs:comment "Companies House UK - We incorporate and dissolve limited companies. We register company information and make it available to the public."@en ;
+    rdfs:comment "Companies House UK - Incorporamos y disolvemos sociedades limitadas. Registramos la información de la empresa y la ponemos a disposición del público."@es .
+
+#
+# Authentication.
+#
+inrupt_3rd_party_companies_house_uk:authenticationApiEndpoint a rdf:Property, owl:ObjectProperty ;
+    rdfs:isDefinedBy inrupt_3rd_party_companies_house_uk: ;
+    rdfs:label "Authentication API endpoint"@en ;
+    rdfs:label "Punto final de la API de autenticación"@es ;
+    rdfs:comment "Authentication API endpoint."@en ;
+    rdfs:comment "Punto final de la API de autenticación."@es .
+
+inrupt_3rd_party_companies_house_uk:authenticationUsername a rdf:Property, owl:ObjectProperty ;
+    rdfs:isDefinedBy inrupt_3rd_party_companies_house_uk: ;
+    rdfs:label "Username"@en ;
+    rdfs:label "Nombre de usuario"@es ;
+    rdfs:comment "Username used to authenticate for API access."@en ;
+    rdfs:comment "Nombre de usuario utilizado para autenticarse para el acceso a la API."@es .
+
+inrupt_3rd_party_companies_house_uk:authenticationPassword a rdf:Property, owl:ObjectProperty ;
+    rdfs:isDefinedBy inrupt_3rd_party_companies_house_uk: ;
+    rdfs:label "Password"@en ;
+    rdfs:label "Contraseña"@es ;
+    rdfs:comment "Password used to authenticate for API access."@en ;
+    rdfs:comment "Contraseña utilizada para autenticarse para el acceso a la API."@es .
+
+inrupt_3rd_party_companies_house_uk:authenticationHttpBasicToken a rdf:Property, owl:ObjectProperty ;
+    rdfs:isDefinedBy inrupt_3rd_party_companies_house_uk: ;
+    rdfs:label "HTTP basic token"@en ;
+    rdfs:label "Token básico HTTP"@es ;
+    rdfs:comment "HTTP basic token used to authenticate for API access."@en ;
+    rdfs:comment "Token básico HTTP que se utiliza para autenticar el acceso a la API."@es .
+
+#
+# General terms...
+#
+
+inrupt_3rd_party_companies_house_uk:status a rdf:Property, owl:ObjectProperty ;
+    rdfs:isDefinedBy inrupt_3rd_party_companies_house_uk: ;
+    rdfs:label "Status"@en ;
+    rdfs:label "Estado"@es ;
+    rdfs:comment "Company status (e.g., active, in liquidation, in the course of dissolution, in receivership, or dissolved)."@en ;
+    rdfs:comment "Estado de la empresa (por ejemplo, activa, en liquidación, en proceso de disolución, en suspensión de pagos o disuelta)."@es .
+
+
+inrupt_3rd_party_companies_house_uk:searchResult a rdf:Property, owl:ObjectProperty ;
+    rdfs:isDefinedBy inrupt_3rd_party_companies_house_uk: ;
+    rdfs:label "Search result"@en ;
+    rdfs:label "Resultado de búsqueda"@es ;
+    rdfs:comment "Company search result (via our search API)."@en ;
+    rdfs:comment "Resultado de búsqueda de la empresa (a través de nuestra API de búsqueda)."@es .
+
+#
+#inrupt_3rd_party_companies_house_uk: a rdf:Property, owl:ObjectProperty ;
+#    rdfs:isDefinedBy inrupt_3rd_party_companies_house_uk: ;
+#    rdfs:label ""@en ;
+#    rdfs:label ""@es ;
+#    rdfs:comment ""@en ;
+#    rdfs:comment ""@es .

--- a/src/vocab/ThirdParty/CopyOfVocab/inrupt-3rd-party-dnb.ttl
+++ b/src/vocab/ThirdParty/CopyOfVocab/inrupt-3rd-party-dnb.ttl
@@ -1,0 +1,60 @@
+prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+prefix xsd: <http://www.w3.org/2001/XMLSchema#>
+prefix owl: <http://www.w3.org/2002/07/owl#>
+prefix vann: <http://purl.org/vocab/vann/>
+prefix dcterms: <http://purl.org/dc/terms/>
+prefix cc: <http://creativecommons.org/ns#>
+prefix skosxl: <http://www.w3.org/2008/05/skos-xl#>
+
+prefix inrupt_gen: <https://inrupt.com/vocab/tool/artifact_generator#>
+prefix inrupt_common: <https://inrupt.com/vocab/common#>
+
+prefix inrupt_3rd_party_dnb: <https://inrupt.com/vocab/3rdparty/dnb#>
+
+#
+# Describe our vocabulary - i.e., an English description, its version, who created it, its
+# suggested prefix, its license, etc.
+#
+inrupt_3rd_party_dnb: a owl:Ontology, inrupt_gen:Ontology  ;
+     owl:versionInfo "0.0.1" ;
+     owl:versionIRI <https://inrupt.com/vocab/3rdparty/dnb/0.0.1> ;
+     dcterms:title
+         "Inrupt vocabulary for D&B APIs"@en ,
+         "Vocabulario de Inrupt para las API de D&B"@es ;
+     dcterms:description
+         "Inrupt vocabulary created to represent terms from D&B APIs."@en ,
+         "Vocabulario de Inrupt creado para representar términos de las API de D&B."@es ;
+     dcterms:creator <https://inrupt.com/profile/card/#us> ;
+     dcterms:issued "2021-08-23"^^xsd:date ;
+     vann:preferredNamespacePrefix "inrupt_3rd_party_dnb" ;
+     vann:preferredNamespaceUri <https://inrupt.com/vocab/3rdparty/dnb#> ;
+     cc:attributionURL inrupt_3rd_party_dnb: ;
+     cc:license <https://creativecommons.org/publicdomain/zero/1.0/> .
+
+#
+# Identifier for the corporate entity representing this data source.
+#
+inrupt_3rd_party_dnb:Dnb a owl:NamedIndividual ;
+    rdfs:isDefinedBy inrupt_3rd_party_dnb: ;
+    rdfs:seeAlso <https://dnb.com/> ;
+    rdfs:label "Dun & BradStreet (D&B)"@en ;
+    rdfs:label "Dun & BradStreet (D&B)"@es ;
+    rdfs:comment "Dun & BradStreet, the business information company."@en ;
+    rdfs:comment "Dun & BradStreet, la empresa de información empresarial."@es .
+
+inrupt_3rd_party_dnb:DunsNumber rdfs:subClassOf inrupt_common:CustomerId ;
+    rdfs:isDefinedBy inrupt_3rd_party_dnb: ;
+    rdfs:label "Class of DUNS Numbers"@en ;
+    rdfs:label "Clase de números DUNS"@es ;
+    rdfs:comment """The class of corporate identifiers from Dun & Bradstreet (D&B)."""@en ;
+    rdfs:comment """La clase de identificadores corporativos de Dun & Bradstreet (D&B)."""@es ;
+    rdfs:seeAlso <https://ask.dnb.co.uk/help/duns-number/duns-number> .
+
+inrupt_3rd_party_dnb:dunsNumber rdfs:subPropertyOf inrupt_common:customerId ;
+    rdfs:isDefinedBy inrupt_3rd_party_dnb: ;
+    rdfs:label "DUNS Number"@en ;
+    rdfs:label "Número DUNS"@es;
+    rdfs:comment "DUNS Number - a corporate identifier from Dun & Bradstreet (D&B)"@en ;
+    rdfs:comment "Número DUNS: un identificador corporativo de Dun & Bradstreet (D&B)"@es ;
+    rdfs:seeAlso <https://ask.dnb.co.uk/help/duns-number/duns-number> .

--- a/src/vocab/ThirdParty/CopyOfVocab/inrupt-3rd-party-passport-office-uk.ttl
+++ b/src/vocab/ThirdParty/CopyOfVocab/inrupt-3rd-party-passport-office-uk.ttl
@@ -1,0 +1,66 @@
+prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+prefix xsd: <http://www.w3.org/2001/XMLSchema#>
+prefix owl: <http://www.w3.org/2002/07/owl#>
+prefix vann: <http://purl.org/vocab/vann/>
+prefix dcterms: <http://purl.org/dc/terms/>
+prefix cc: <http://creativecommons.org/ns#>
+prefix skosxl: <http://www.w3.org/2008/05/skos-xl#>
+
+prefix inrupt_gen: <https://inrupt.com/vocab/tool/artifact_generator#>
+prefix inrupt_common: <https://inrupt.com/vocab/common#>
+
+prefix inrupt_3rd_party_passport_office_uk: <https://inrupt.com/vocab/3rdparty/pasport_office_uk#>
+
+#
+# Describe our vocabulary - i.e., an English description, its version, who created it, its
+# suggested prefix, its license, etc.
+#
+inrupt_3rd_party_passport_office_uk: a owl:Ontology, inrupt_gen:Ontology  ;
+     owl:versionInfo "0.0.1" ;
+     owl:versionIRI <https://inrupt.com/vocab/3rdparty/pasport_office_uk/0.0.1> ;
+     dcterms:title
+         "Inrupt vocabulary for the Passport Office of the UK"@en ,
+         "Vocabulario ininterrumpido para la Oficina de Pasaportes del Reino Unido"@es ;
+     dcterms:description
+         "Inrupt vocabulary for the Passport Office of the UK"@en ,
+         "Vocabulario ininterrumpido para la Oficina de Pasaportes del Reino Unido"@es ;
+     dcterms:creator <https://inrupt.com/profile/card/#us> ;
+     dcterms:issued "2021-08-23"^^xsd:date ;
+     vann:preferredNamespacePrefix "inrupt_3rd_party_passport_office_uk" ;
+     vann:preferredNamespaceUri <https://inrupt.com/vocab/3rdparty/pasport_office_uk#> ;
+     cc:attributionURL inrupt_3rd_party_passport_office_uk: ;
+     cc:license <https://creativecommons.org/publicdomain/zero/1.0/> .
+
+#
+# Identifier for the corporate entity representing this data source.
+#
+inrupt_3rd_party_passport_office_uk:PassportOffice a owl:NamedIndividual ;
+    rdfs:isDefinedBy inrupt_3rd_party_passport_office_uk: ;
+    rdfs:seeAlso <https://www.gov.uk/government/organisations/hm-passport-office> ;
+    rdfs:label "Passport office UK"@en ;
+    rdfs:label "Oficina de pasaportes del Reino Unido"@es ;
+    rdfs:comment "HM Passport Office is the sole issuer of UK passports and responsible for civil registration services through the General Register Office."@en ;
+    rdfs:comment "HM Passport Office es el único emisor de pasaportes del Reino Unido y responsable de los servicios de registro civil a través de la Oficina de Registro General."@es .
+
+inrupt_3rd_party_passport_office_uk:Passport a rdfs:Class, owl:Class ;
+    rdfs:isDefinedBy inrupt_3rd_party_passport_office_uk: ;
+    rdfs:label "Passport"@en ;
+    rdfs:label "Pasaporte"@es ;
+    rdfs:comment """The class of passports."""@en ;
+    rdfs:comment """La clase de pasaportes."""@es .
+
+inrupt_3rd_party_passport_office_uk:passport a rdf:Property, owl:ObjectProperty ;
+    rdfs:isDefinedBy inrupt_3rd_party_passport_office_uk: ;
+    rdfs:label "Passport"@en ;
+    rdfs:label "Pasaporte"@es ;
+    rdfs:comment """Passport for international travel."""@en ;
+    rdfs:comment """Pasaporte para viajes internacionales."""@es .
+
+
+inrupt_3rd_party_passport_office_uk:passportNumber a rdf:Property, owl:ObjectProperty ;
+    rdfs:isDefinedBy inrupt_3rd_party_passport_office_uk: ;
+    rdfs:label "Passport number"@en ;
+    rdfs:label "Número de pasaporte"@es;
+    rdfs:comment "Passport number that uniquely identifies an instance of a passport."@en ;
+    rdfs:comment "Número de pasaporte que identifica de forma única una instancia de un pasaporte."@es .

--- a/src/vocab/ThirdParty/CopyOfVocab/inrupt-3rd-party-unilever.ttl
+++ b/src/vocab/ThirdParty/CopyOfVocab/inrupt-3rd-party-unilever.ttl
@@ -1,0 +1,82 @@
+prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+prefix xsd: <http://www.w3.org/2001/XMLSchema#>
+prefix owl: <http://www.w3.org/2002/07/owl#>
+prefix vann: <http://purl.org/vocab/vann/>
+prefix dcterms: <http://purl.org/dc/terms/>
+prefix cc: <http://creativecommons.org/ns#>
+prefix skosxl: <http://www.w3.org/2008/05/skos-xl#>
+
+prefix inrupt_gen: <https://inrupt.com/vocab/tool/artifact_generator#>
+prefix inrupt_common: <https://inrupt.com/vocab/common#>
+
+prefix inrupt_3rd_party_unilever: <https://unilever.com/vocab/unilever#>
+
+#
+# Describe our vocabulary - i.e., an English description, its version, who created it, its
+# suggested prefix, its license, etc.
+#
+inrupt_3rd_party_unilever: a owl:Ontology, inrupt_gen:Ontology  ;
+     owl:versionInfo "0.0.1" ;
+     owl:versionIRI <https://unilever.com/vocab/unilever/0.0.1> ;
+     dcterms:title "Vocabulary for Unilever" ;
+     dcterms:description """A vocabulary for common terms used across Unilever."""@en ;
+     dcterms:creator <https://inrupt.com/profile/card/#us> ;
+     dcterms:issued "2022-01-12"^^xsd:date ;
+     vann:preferredNamespacePrefix "inrupt_3rd_party_unilever" ;
+     vann:preferredNamespaceUri <https://unilever.com/vocab/unilever#> ;
+     cc:attributionURL inrupt_3rd_party_unilever: ;
+     cc:license <https://creativecommons.org/publicdomain/zero/1.0/> .
+
+#
+# THESE TERMS HAVE BEEN MOVED TO THE INRUPT COMMON VOCAB - REMOVE FROM HERE ONCE THAT'S PUBLISHED!
+#
+inrupt_3rd_party_unilever:Tag a rdfs:Class, owl:Class ;
+    rdfs:isDefinedBy inrupt_3rd_party_unilever: ;
+    rdfs:label "Tag"@en ;
+    rdfs:label "Etiqueta"@es ;
+    rdfs:comment "The class of tags."@en ;
+    rdfs:comment "La clase de etiquetas."@es .
+
+inrupt_3rd_party_unilever:tag a rdf:Property, owl:ObjectProperty ;
+    rdfs:isDefinedBy inrupt_3rd_party_unilever: ;
+    rdfs:label "Tag"@en ;
+    rdfs:label "Etiqueta"@es ;
+    rdfs:comment "Property used to denote that an entity has a specific tag."@en ;
+    rdfs:comment "Propiedad utilizada para indicar que una entidad tiene una etiqueta específica."@es .
+
+#
+# Here we just hypothetically suggest that Unilever defines terms for their
+# newly announced corporate structure (Jan 2022):
+#   https://www.unilever.com/news/press-and-media/press-releases/2022/unilever-simplifies-organisation/
+# Now they have 5 distinct business groups, so we associate simple tags:
+#   Beauty & Wellbeing, Personal Care, Home Care, Nutrition, and Ice Cream
+#
+inrupt_3rd_party_unilever:Tag_Travel a inrupt_3rd_party_unilever:Tag, owl:NamedIndividual ;
+    rdfs:isDefinedBy inrupt_3rd_party_unilever: ;
+    rdfs:label "Travel"@en ;
+    rdfs:label "Viajar"@es ;
+    rdfs:comment "Travel tag - used to mark something as being related to travel."@en ;
+    rdfs:comment "Etiqueta de viaje: se utiliza para marcar algo relacionado con un viaje."@es .
+
+inrupt_3rd_party_unilever:Tag_Finance a inrupt_3rd_party_unilever:Tag, owl:NamedIndividual ;
+    rdfs:isDefinedBy inrupt_3rd_party_unilever: ;
+    rdfs:label "Finance"@en ;
+    rdfs:label "Finanzas"@es ;
+    rdfs:comment "Finance tag - used to mark something as being related to finance."@en ;
+    rdfs:comment "Etiqueta financiera: se usa para marcar algo como relacionado con las finanzas."@es .
+
+inrupt_3rd_party_unilever:Tag_Id a inrupt_3rd_party_unilever:Tag, owl:NamedIndividual ;
+    rdfs:isDefinedBy inrupt_3rd_party_unilever: ;
+    rdfs:label "ID"@en ;
+    rdfs:label "ID"@es ;
+    rdfs:comment "ID tag - used to mark something as being related to identity (e.g., a passport, or drivers license)."@en ;
+    rdfs:comment "Etiqueta de identificación: se usa para marcar algo relacionado con la identidad (por ejemplo, un pasaporte o una licencia de conducir)."@es .
+
+#
+#inrupt_3rd_party_unilever: a rdf:Property, owl:ObjectProperty ;
+#    rdfs:isDefinedBy inrupt_3rd_party_unilever: ;
+#    rdfs:label ""@en ;
+#    rdfs:label ""@es ;
+#    rdfs:comment ""@en ;
+#    rdfs:comment ""@es .

--- a/src/vocab/vocab-gds-poc-bundle-all.yml
+++ b/src/vocab/vocab-gds-poc-bundle-all.yml
@@ -1,0 +1,317 @@
+#
+# This file contains a simple list of vocabularies that we bundle together to
+# form the collective set of 3rd-party vocabularies.
+#
+# We define these vocabularies on behalf of 3rd parties that do not (yet)
+# provide RDF vocabularies for their APIs.
+#
+# Local vocabularies can be provided relative to the location of this resource
+# list file.
+#
+artifactName: vocab-etl-tutorial-bundle-all
+artifactGeneratorVersion: 2.0.0
+
+#
+# This versioning information is optional, and is useful for published
+# packages - since we aren't yet publishing anything for this project yet,
+# this section is commented out.
+#
+#versioning:
+#  type: git
+#  # Hypothetical GitHub repository if we wished to publish this
+#  # vocabulary information...
+#  # For example, Inrupt publishes its vocabulary information here:
+#  #  url: https://github.com/inrupt/solid-common-vocab-rdf.git
+#  versioningTemplates:
+#    - templateInternal: ".gitignore.hbs"
+#      fileName: ".gitignore"
+
+license:
+  path: "./LICENSE"
+  fileName: "LICENSE"
+  header: "./LICENSE_HEADER.js"
+  name: "Proprietary"
+
+artifactToGenerate:
+#  # This is the configuration of the DEFAULT Java artifact - i.e., where the name
+#  # of the generated JAR does not contain details of its dependencies (e.g.
+#  # whether it provides SolidCommonVocab constants or just string constants, or whether
+#  # it depends on RDF4J or Jena or RDF Commons, etc.).
+#  - programmingLanguage: Java
+#    artifactVersion: 0.8.2-SNAPSHOT
+#    artifactNamePrefix: ""
+#    artifactNameSuffix: ""
+#
+#    artifactDirectoryName: Java
+#    sourceFileExtension: java
+#    javaPackageName: com.inrupt.vocab.thirdparty
+#
+#    templateInternal: stringLiteral/java/vocab.hbs
+#
+#    # Currently we're just adding terms as they occur in vocabs, and not all possible keywords.
+#    languageKeywordsToUnderscore:
+#      - class     # Defined in VCard.
+#      - abstract  # Defined in DCTerms.
+#      - default   # Defined in ACL
+#    packaging:
+#      - packagingTool: maven
+#        groupId: com.inrupt
+#        publish:
+#          - key: "mavenLocal"
+#            command: "mvn --version && mvn install"
+#          - key: "mavenRemote"
+#            command: "mvn deploy"
+#          - key: "cloudsmith"
+#            command: "mvn -s /home/runner/work/solid-common-vocab-rdf/solid-common-vocab-rdf/settings.xml deploy --log-file ../../../mvn-deploy.log"
+#        packagingTemplates:
+#          - templateInternal: stringLiteral/java/pom.hbs
+#            fileName: pom.xml
+#        repository:
+#          - type: repository
+#            id: cloudsmith-staging
+#            url: https://maven.cloudsmith.io/inrupt/sdk-staging/
+#          - type: snapshotRepository
+#            id: cloudsmith-development
+#            url: https://maven.cloudsmith.io/inrupt/sdk-development/
+#
+#
+#  # This is the configuration of the DEFAULT TypeScript artifact - i.e., where
+#  # the name of the generated npm module does not contain details of its
+#  # dependencies (e.g., whether it provides SolidCommonVocab constants or just string
+#  # literals, or whether it depends on RDF/JS or Jena or RDF Commons, etc.).
+#  - programmingLanguage: TypeScript
+#    artifactVersion: "1.0.1"
+#    artifactNamePrefix: ""
+#    artifactNameSuffix: ""
+#
+#    artifactDirectoryName: TypeScript
+#    sourceFileExtension: ts
+#
+#    templateInternal: stringLiteral/typescript/vocab.hbs
+#
+#    packaging:
+#      - packagingTool: npm
+#        npmModuleScope: "@inrupt/"
+#        bundleName: "Vocabinrupt3rdParty"
+#
+#        typescriptVersion: "^4.7.4"
+#        rollupVersion: "^2.36.1"
+#        rollupTypescriptPluginVersion: "^0.29.0"
+#        rollupCommonjsPluginVersion: "^17.0.0"
+#        rollupNodeResolveVersion: "^11.0.1"
+#
+#        publish:
+#          - key: "npmInstallAndBuild"
+#            command: "npm install && npm run build"
+#          - key: "npmLocal"
+#            command: "npm unpublish --force --registry http://localhost:4873/ && npm install --registry http://localhost:4873/ && npm run build && npm publish --registry http://localhost:4873/"
+#          # The following command should only run in CI.
+#          - key: "npmPublic"
+#            command: "npm install --registry https://registry.npmjs.org/ && npm run build && npm publish --registry https://registry.npmjs.org/ --access public"
+#        packagingTemplates:
+#          - templateInternal: stringLiteral/typescript/package.hbs
+#            fileName: package.json
+#          - templateInternal: generic/typescript/index.hbs-JS
+#            fileName: index.ts
+#          - templateInternal: generic/typescript/tsconfig.hbs
+#            fileName: tsconfig.json
+#          - templateInternal: generic/typescript/rollup.config.hbs
+#            fileName: rollup.config.js
+#
+#
+  # This is the configuration of the DEFAULT SolidCommonVocab TypeScript
+  # artifact - i.e., where the name of the generated npm module does not
+  # contain details of the underlying RDF library dependencies (e.g.,
+  # whether it depends on RDF/JS or a specific implementation, etc.).
+  - programmingLanguage: TypeScript
+    artifactVersion: "1.0.1"
+    artifactNamePrefix: ""
+
+    artifactDirectoryName: TypeScript-SolidCommonVocab
+    sourceFileExtension: ts
+    artifactNameSuffix: -solidcommonvocab
+
+    solidCommonVocabVersion: "^1.0.1"
+    rdfjsTypesVersion: "^1.1.0"
+    rdfjsImplVersion: "^1.1.1"
+    templateInternal: solidCommonVocabDependent/typescript/rdfjsRdfDataFactory/vocab.hbs
+
+    packaging:
+      - packagingTool: npm
+        npmModuleScope: "@inrupt/"
+        bundleName: "Vocabinrupt3rdParty"
+
+        typescriptVersion: "^4.7.4"
+        rollupVersion: "^2.36.1"
+        rollupTypescriptPluginVersion: "^0.29.0"
+        rollupCommonjsPluginVersion: "^17.0.0"
+        rollupNodeResolveVersion: "^11.0.1"
+
+        publish:
+          - key: "npmInstallAndBuild"
+            command: "npm install && npm run build"
+          - key: "npmLocal"
+            command: "npm unpublish --force --registry http://localhost:4873/ && npm install --registry http://localhost:4873/ && npm run build && npm publish --registry http://localhost:4873/"
+          - key: 'npmGithub'
+            command: "npm install --registry https://npm.pkg.github.com/inrupt && npm run build && npm publish --registry https://npm.pkg.github.com/inrupt"
+          - key: "npmPrivate"
+            command: "npm install --registry https://registry.npmjs.org/ && npm publish --registry https://registry.npmjs.org/"
+        packagingTemplates:
+          - templateInternal: solidCommonVocabDependent/typescript/rdfjsRdfDataFactory/package.hbs
+            fileName: package.json
+
+          #
+          # Demonstration here of using a local copy of an Artifact Generator
+          # template and modifying it for our purposes (e.g., in this case to
+          # explicitly export a couple of low-level entities that we need
+          # direct access to in our Node.js code)...
+          #
+#          - templateInternal: generic/typescript/index.hbs
+          - templateCustom: ./GovUk-Gds/Template/solidCommonVocabDependent/javascript/index.hbs
+            fileName: index.ts
+
+          - templateInternal: generic/typescript/tsconfig.hbs
+            fileName: tsconfig.json
+          - templateInternal: generic/typescript/rollup.config.hbs
+            fileName: rollup.config.js
+
+#
+#  - programmingLanguage: TypeScript
+#    artifactVersion: "1.0.1"
+#    artifactNamePrefix: ""
+#    artifactNameSuffix: -rdfdatafactory
+#
+#    artifactDirectoryName: TypeScript-RdfDataFactory
+#    sourceFileExtension: ts
+#
+#    rdfjsTypesVersion: "^1.0.1"
+#    rdfjsImplVersion: "^1.1.0"
+#    templateInternal: rdfLibraryDependent/typescript/rdfjsRdfDataFactory/vocab.hbs
+#
+#    packaging:
+#      - packagingTool: npm
+#        npmModuleScope: "@inrupt/"
+#        bundleName: "Vocabinrupt3rdParty"
+#
+#        typescriptVersion: "^4.7.4"
+#        rollupVersion: "^2.36.1"
+#        rollupTypescriptPluginVersion: "^0.29.0"
+#        rollupCommonjsPluginVersion: "^17.0.0"
+#        rollupNodeResolveVersion: "^11.0.1"
+#
+#        publish:
+#          - key: "npmInstallAndBuild"
+#            command: "npm install && npm run build"
+#          - key: "npmLocal"
+#            command: "npm unpublish --force --registry http://localhost:4873/ && npm install --registry http://localhost:4873/ && npm run build && npm publish --registry http://localhost:4873/"
+#          # The following command should only run in CI.
+#          - key: "npmPublic"
+#            command: "npm install --registry https://registry.npmjs.org/ && npm run build && npm publish --registry https://registry.npmjs.org/ --access public"
+#        packagingTemplates:
+#          - templateInternal: rdfLibraryDependent/typescript/rdfjsRdfDataFactory/package.hbs
+#            fileName: package.json
+#          - templateInternal: generic/typescript/index.hbs-JS
+#            fileName: index.ts
+#          - templateInternal: generic/typescript/tsconfig.hbs
+#            fileName: tsconfig.json
+#          - templateInternal: generic/typescript/rollup.config.hbs
+#            fileName: rollup.config.js
+
+
+vocabList:
+  - widocoLanguages: en-es-cy
+    inputResources:
+      - ./GovUk-Gds/CopyOfVocab/gov-uk-gds-poc.ttl
+
+  - widocoLanguages: en-es-cy
+    inputResources:
+      - ./GovUk-Gds/CopyOfVocab/gov-uk-gds-poc-message.ttl
+
+  #
+  # Just some example vocabularies we define on behalf of 3rd-parties (until
+  # they get around to defining and publishing their own authoritative
+  # vocabularies!).
+  #
+  - widocoLanguages: en-es
+    inputResources:
+      - ./ThirdParty/CopyOfVocab/inrupt-3rd-party-companies-house-uk.ttl
+
+  - widocoLanguages: en-es
+    inputResources:
+      - ./ThirdParty/CopyOfVocab/inrupt-3rd-party-unilever.ttl
+
+  - widocoLanguages: en-es
+    inputResources:
+      - ./ThirdParty/CopyOfVocab/inrupt-3rd-party-dnb.ttl
+
+  - widocoLanguages: en-es
+    inputResources:
+      - ./ThirdParty/CopyOfVocab/inrupt-3rd-party-passport-office-uk.ttl
+
+  # We'd also like to be able to extend the Inrupt Common vocabulary too, but
+  # that's currently only published publicly on GitHub, and so we need to use
+  # the Artifact Generator's ability to override HTTP headers to pull that
+  # vocab as 'raw content', and then parse it as Turtle.
+  #
+  # Note: Unfortunately, GitHub has a rate limit of only 60 unauthenticated
+  # requests per hour - after which we get JSON responses back (telling us our
+  # rate limit has been reached), but that blows up the parser 'cos it's
+  # expecting Turtle (i.e., "Error: Unexpected literal on line 1.").
+  #
+  # Note: Doing this raises import issues too - i.e., we are almost certainly
+  # importing the Inrupt Common bundle anyway, and so trying to extend just
+  # this one vocab means our IDE will offer two very confusing choices if we
+  # don't name our extension of that vocabulary differently.
+#  - vocabAcceptHeaderOverride: application/vnd.github.v3.raw
+#    vocabContentTypeHeaderOverride: text/turtle
+#    inputResources:
+#      - https://api.github.com/repos/inrupt/solid-common-vocab-rdf/contents/inrupt-rdf/Core/CopyOfVocab/inrupt-common.ttl
+#      - ./EtlTutorial/Extension/inrupt-common-etl-tutorial-ext.ttl
+
+  # Unfortunately the above approach (which works on local development
+  # machines) seems to fail when run from GitHub CI. Until we can look into
+  # that fully, we can just make a copy of the Inrupt Common vocab locally in
+  # our Extensions directory!
+#  - inputResources:
+#      - ./GovUk-Gds/Extension/inrupt-common-TEMP_COPY.ttl
+#      - ./GovUk-Gds/Extension/inrupt-common-etl-tutorial-ext.ttl
+
+
+  # These will be included in the next release of the 'Common RDF' bundle from
+  # Inrupt, but including here shows how flexible and powerful the Artifact
+  # Generator is - in that we could choose to cherry-pick individual terms, or
+  # extend terms with extra `rdfs:label` or `rdfs:comment` translations, etc.
+  - inputResources:
+      - https://w3id.org/dpv#
+
+  - inputResources:
+      - https://w3id.org/dpv/dpv-pd#
+
+
+  - inputResources:
+      - https://ontologies.semanticarts.com/o/gistCore11.0.0
+    nameAndPrefixOverride: gist
+    namespaceOverride: https://ontologies.semanticarts.com/gist/
+
+
+
+  #
+  # Rather than pull in the published Inrupt 'Common RDF' bundle (which is
+  # due a release soon), we just pull in the specific 'Common' vocabs we use
+  # so far ourselves (this is a nice demonstration of how easy it is to
+  # configure the Artifact Generator for your immediate or specific needs).
+  #
+  - nameAndPrefixOverride: rdf
+    inputResources:
+      - http://www.w3.org/1999/02/22-rdf-syntax-ns#
+
+  - description: Dublin Core Terms - for describing resources
+    nameAndPrefixOverride: dcterms
+    inputResources:
+      - http://dublincore.org/2012/06/14/dcterms.ttl
+
+  - description: Inrupt-determined cherry-picked Schema.org terms (that include label and comment translations)
+    nameAndPrefixOverride: schema_inrupt
+    inputResources:
+      - https://schema.org/version/latest/schemaorg-current-http.ttl
+    termSelectionResource: ./GovUk-Gds/Extension/schema-inrupt-ext.ttl


### PR DESCRIPTION
Kinda big PR, adding multi-lingual messaging (in Englsh, Welsh, and Spanish) for the 'Login' and 'Access Logs' screens.
Simply use <Ctrl-R> repeatedly to refresh the 'Login' screen to see it iterate through the 3 language options - and whichever language you 'land on' will persist after you click the 'Login' button to the 'Access Logs' screen.
You can then go back to the Login screen and refresh repeatedly again to select your new preferred language, and then click login again to see the 'Access Logs' screen messaging in your newly selected language.