### PR TITLE
GUA-247: Check pod for previously saved credentials

### DIFF
--- a/src/controllers/identity/ipv.ts
+++ b/src/controllers/identity/ipv.ts
@@ -1,5 +1,15 @@
 import { Request, Response } from "express";
 
+export function proveIdentityStartGet(req: Request, res: Response) {
+  const hasPreviousCredentials = false
+
+  if (hasPreviousCredentials) {
+    res.redirect("/identity/use-saved-proof-of-identity")
+  } else(
+    res.redirect("identity/prove-identity")
+  )
+}
+
 /* Prove your Identity */
 export function proveIdentityLoggedOutGet(req: Request, res: Response) {
   res.render("identity/prove-identity-logged-out");

--- a/src/controllers/identity/ipv.ts
+++ b/src/controllers/identity/ipv.ts
@@ -155,3 +155,7 @@ export function securityQuestionPost(req: Request, res: Response) {
 export function checkInPersonGet(req: Request, res: Response) {
   res.render("identity/check-in-person");
 }
+
+export function useSavedProofOfIdentityGet(req: Request, res: Response) {
+  res.render("identity/use-saved-proof-of-identity")
+}

--- a/src/controllers/identity/ipv.ts
+++ b/src/controllers/identity/ipv.ts
@@ -1,13 +1,16 @@
 import { Request, Response } from "express";
+import { getSessionFromStorage } from "@inrupt/solid-client-authn-node";
+import { hasSavedIdentityChecks } from "../../lib/pod"
 
-export function proveIdentityStartGet(req: Request, res: Response) {
-  const hasPreviousCredentials = false
-
-  if (hasPreviousCredentials) {
-    res.redirect("/identity/use-saved-proof-of-identity")
-  } else(
-    res.redirect("identity/prove-identity")
-  )
+export async function proveIdentityStartGet(req: Request, res: Response) {
+  const session = await getSessionFromStorage(req.session?.sessionId);
+  if (session) {
+    if (await hasSavedIdentityChecks(session)) {
+      res.redirect("/identity/use-saved-proof-of-identity")
+    } else(
+      res.redirect("identity/prove-identity")
+    )
+  }
 }
 
 /* Prove your Identity */

--- a/src/controllers/login.ts
+++ b/src/controllers/login.ts
@@ -31,6 +31,6 @@ export async function callbackGet(req: Request, res: Response): Promise<void> {
     if (response.status == 404) {
       await createProfileAndPod(session)
     }
-    res.render('identity/prove-identity-logged-out', { webId: session.info.webId })
+    res.redirect("/identity")
   }
 }

--- a/src/lib/pod.ts
+++ b/src/lib/pod.ts
@@ -115,3 +115,13 @@ async function writeFileToPod(file: Blob, targetFileURL: string, session: Sessio
     console.error(error);
   }
 }
+
+export async function hasSavedIdentityChecks(session: Session): Promise<boolean> {
+  try {
+    await getSolidDataset(await getDatasetUri(session, 'private/govuk/identity/poc/credentials-pat/vcs/kbv/metadata'), {fetch: session.fetch})
+    await getSolidDataset(await getDatasetUri(session, 'private/govuk/identity/poc/credentials-pat/vcs/passport/metadata'), {fetch: session.fetch})
+  } catch (FetchError) {
+    return false
+  }
+  return true
+}

--- a/src/routes/identity.ts
+++ b/src/routes/identity.ts
@@ -30,6 +30,7 @@ import {
   enterPassportPost,
   findAddressPost,
   proveIdentityLoggedOutPost,
+  proveIdentityStartGet,
   securityQuestionPost,
   checkInPersonGet,
 } from "../controllers/identity/ipv"
@@ -52,6 +53,10 @@ async function redirectIfNotLoggedIn(req: Request, res: Response, next: NextFunc
 router.use((req: Request, res: Response, next: NextFunction) => {
     redirectIfNotLoggedIn(req, res, next);
 })
+
+
+/* Check if someone has stored credentials */
+router.get('/', proveIdentityStartGet)
 
 /* Begin Journey, NB not in figma? */
 router.get('/prove-identity-logged-out', proveIdentityLoggedOutGet);

--- a/src/routes/identity.ts
+++ b/src/routes/identity.ts
@@ -33,6 +33,7 @@ import {
   proveIdentityStartGet,
   securityQuestionPost,
   checkInPersonGet,
+  useSavedProofOfIdentityGet
 } from "../controllers/identity/ipv"
 
 import { getSessionFromStorage } from "@inrupt/solid-client-authn-node";
@@ -106,5 +107,8 @@ router.get('/check-in-person', checkInPersonGet)
 /* IPV Core completion pages */
 router.get('/complete/saved', completeSavedGet);
 router.get('/complete/return', completeReturnGet);
+
+/* Re-use identity page */
+router.get('/use-saved-proof-of-identity', useSavedProofOfIdentityGet)
 
 export { router as identityRouter };


### PR DESCRIPTION
When a user first starts the IPV journey, check their pod for any
previously stored credentials. If both the credentials are there, take
them past the questions to the re-use page.

Note: We're not doing any validation of these credentials, or even
checking the binary JWTs are present - we're only looking to see that
there's resources at the metadata paths where we're expecting them to
be. This is a deliberate choice made to speed up the development of
this PoC; in the real thing we'd need to fetch the JWTs, decode them
and run validity checks or re-use the data for other CRIs.

The 'use saved identity' page doesn't lead on to the rest 
of the journey yet, there's still some connecting that needs doing.