### PR TITLE
BAU: Close login request once user is sent to IDp

### DIFF
--- a/src/controllers/login.ts
+++ b/src/controllers/login.ts
@@ -4,7 +4,7 @@ import { getSessionFromStorage, Session } from "@inrupt/solid-client-authn-node"
 import { getHostname, getClientId, getEssServiceURI, EssServices } from "../config";
 import { createProfileAndPod } from "../lib/pod";
 
-export async function loginGet(req: Request, res: Response): Promise<void> {
+export function loginGet(req: Request, res: Response): void {
   const session = new Session();
   if (req.session != undefined) {
     req.session.sessionId = session.info.sessionId;
@@ -13,7 +13,7 @@ export async function loginGet(req: Request, res: Response): Promise<void> {
     }
   }
   const redirectToSolidIdentityProvider = (url: string) => { res.redirect(url); };
-  await session.login({
+  session.login({
     redirectUrl: `${getHostname()}/login/callback`,
     clientId: getClientId('production'),
     oidcIssuer: getEssServiceURI(EssServices.OpenId),


### PR DESCRIPTION
This was causing the app to crash when a user spent more than 3.5
seconds logging into their account as that's the default request
timeout length in Express.

Changing the login function to not `await` for the response from
`session.login` closes the request once the user's been redirected to
the IDp. This has no impact on how the login works or what the user
sees.

This is the only part of the `loginGet` function that's async so we can
also make the whole function synchronous now.