### PR TITLE
GUA 231 account home area

### DIFF
--- a/src/controllers/account.ts
+++ b/src/controllers/account.ts
@@ -1,6 +1,7 @@
 import { Request, Response } from "express";
 import { getSessionFromStorage } from "@inrupt/solid-client-authn-node";
-import { hasSavedIdentityChecks } from "../lib/pod";
+import { deleteFile } from "@inrupt/solid-client";
+import { hasSavedIdentityChecks, getDatasetUri } from "../lib/pod";
 
 export async function accountSettingsGet(
   req: Request,
@@ -41,4 +42,36 @@ export async function deleteYourProofOfIdGet(
   res: Response
 ): Promise<void> {
   res.render("account/delete-proof-of-identity");
+}
+
+export async function deleteYourProofOfIdPost(
+  req: Request,
+  res: Response
+): Promise<void> {
+  const session = await getSessionFromStorage(req.session?.sessionId);
+  if (session) {
+    const kvbUri = await getDatasetUri(
+      session,
+      "private/govuk/identity/poc/credentials-pat/vcs/kbv/metadata"
+    );
+    const passportUri = await getDatasetUri(
+      session,
+      "private/govuk/identity/poc/credentials-pat/vcs/passport/metadata"
+    );
+    try {
+      await deleteFile(kvbUri, { fetch: session.fetch });
+      console.log(`Deleted:: ${kvbUri}`);
+    } catch (err) {
+      console.error(err);
+    }
+
+    try {
+      await deleteFile(passportUri, { fetch: session.fetch });
+      console.log(`Deleted:: ${passportUri}`);
+    } catch (err) {
+      console.error(err);
+    }
+  }
+
+  res.redirect("/account/settings/your-proof-of-identity");
 }

--- a/src/controllers/account.ts
+++ b/src/controllers/account.ts
@@ -1,4 +1,6 @@
 import { Request, Response } from "express";
+import { getSessionFromStorage } from "@inrupt/solid-client-authn-node";
+import { hasSavedIdentityChecks } from "../lib/pod";
 
 export async function accountSettingsGet(
   req: Request,
@@ -25,7 +27,12 @@ export async function yourProofOfIdGet(
   req: Request,
   res: Response
 ): Promise<void> {
-  res.render("account/your-proof-of-identity");
+  const session = await getSessionFromStorage(req.session?.sessionId);
+  if (session) {
+    res.render("account/your-proof-of-identity", {
+      hasSavedIdentityChecks: await hasSavedIdentityChecks(session),
+    });
+  }
 }
 
 export async function deleteYourProofOfIdGet(

--- a/src/controllers/account.ts
+++ b/src/controllers/account.ts
@@ -28,6 +28,7 @@ export async function yourProofOfIdGet(
   res: Response
 ): Promise<void> {
   const session = await getSessionFromStorage(req.session?.sessionId);
+
   if (session) {
     res.render("account/your-proof-of-identity", {
       hasSavedIdentityChecks: await hasSavedIdentityChecks(session),

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -236,6 +236,10 @@
         "deleteInformationLink": "Delete this information from your account",
         "savedOn": "Saved on [date]"
       },
+      "noSavedIdentity": {
+        "heading": "You do not currently have saved identity credentials",
+        "paragraph1": "You will need to do a full identity check next time you use a relevant government service. Or you can do them now to save time later"
+      },
       "deleteProofOfId": {
         "title": "Delete the information you use to prove your identity",
         "paragraph1": "Confirm you want to permanently delete the information your GOV.UK account uses to prove your identity. This will not delete your account.",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -240,6 +240,10 @@
         "deleteInformationLink": "Delete this information from your account",
         "savedOn": "Saved on [date]"
       },
+      "noSavedIdentity": {
+        "heading": "You do not currently have saved identity credentials",
+        "paragraph1": "You will need to do a full identity check next time you use a relevant government service. Or you can do them now to save time later"
+      },
       "deleteProofOfId": {
         "title": "Delete the information you use to prove your identity",
         "paragraph1": "Confirm you want to permanently delete the information your GOV.UK account uses to prove your identity. This will not delete your account.",

--- a/src/routes/account.ts
+++ b/src/routes/account.ts
@@ -7,6 +7,7 @@ import {
   accountSettingsGet,
   yourProofOfIdGet,
   deleteYourProofOfIdGet,
+  deleteYourProofOfIdPost,
 } from "../controllers/account";
 
 const router = express.Router();
@@ -21,5 +22,6 @@ router.get("/settings", accountSettingsGet);
 router.get("/settings/activity", accountActivityGet);
 router.get("/settings/your-proof-of-identity", yourProofOfIdGet);
 router.get("/settings/your-proof-of-identity/delete", deleteYourProofOfIdGet);
+router.post("/settings/your-proof-of-identity/delete", deleteYourProofOfIdPost);
 
 export default router;

--- a/src/routes/account.ts
+++ b/src/routes/account.ts
@@ -1,4 +1,6 @@
-import express from "express";
+import express, { Request, Response, NextFunction } from "express";
+import redirectIfNotLoggedIn from "../lib/middleware/redirectIfNotLoggedIn";
+
 import {
   accountHomeGet,
   accountActivityGet,
@@ -8,6 +10,11 @@ import {
 } from "../controllers/account";
 
 const router = express.Router();
+
+/* All following routes require someone to be logged in first */
+router.use((req: Request, res: Response, next: NextFunction) => {
+  redirectIfNotLoggedIn(req, res, next);
+});
 
 router.get("/", accountHomeGet);
 router.get("/settings", accountSettingsGet);

--- a/src/views/account/your-proof-of-identity.njk
+++ b/src/views/account/your-proof-of-identity.njk
@@ -1,5 +1,6 @@
 {% extends "layouts/account.njk" %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
 {% set pageTitleName = 'account.pages.yourProofOfId.title' | translate %}
 {% set activeNavLink = '/account/settings'%}
 {% set backLink =  '/account/settings' %}
@@ -8,31 +9,44 @@
   <h1 class="govuk-heading-l govuk-!-margin-bottom-7">{{ 'account.pages.yourProofOfId.title' | translate }}</h1>
   <p class="govuk-body">{{ 'account.pages.yourProofOfId.paragraph1' | translate }}</p>
   <p class="govuk-body">{{ 'account.pages.yourProofOfId.paragraph2' | translate }}</p>
-  <h2 class="govuk-heading-m">{{ 'account.pages.yourProofOfId.summaryListTitle' | translate }}</h2>
-  {{ govukTable({
-    firstCellIsHeader: true,
-    classes: "accounts-table",
-    rows: [
-      [
-        {
-          text: "Passport Based Identity Check",
-          classes: "govuk-!-width-one-half"
-        },
-        {
-          text: 'account.pages.yourProofOfId.savedOn' | translate | replace("[date]", "01 January 2022")
-        }
-      ],
-      [
-        {
-          text: "Knowlege Based Verification (KVB) Identity Check",
-          classes: "govuk-!-width-one-half"
-        },
-        {
-          text: 'account.pages.yourProofOfId.savedOn' | translate | replace("[date]", "02 January 2022")
-        }
-      ]
-    ]
-  }) }}
 
-  <a href="/account/settings/your-proof-of-identity/delete" class="govuk-link govuk-body">{{ 'account.pages.yourProofOfId.deleteInformationLink' | translate }}</a>
+  {% if (hasSavedIdentityChecks) %}
+    <h2 class="govuk-heading-m">{{ 'account.pages.yourProofOfId.summaryListTitle' | translate }}</h2>
+    {{ govukTable({
+      firstCellIsHeader: true,
+      classes: "accounts-table",
+      rows: [
+        [
+          {
+            text: "Passport Based Identity Check",
+            classes: "govuk-!-width-one-half"
+          },
+          {
+            text: 'account.pages.yourProofOfId.savedOn' | translate | replace("[date]", "01 January 2022")
+          }
+        ],
+        [
+          {
+            text: "Knowlege Based Verification (KVB) Identity Check",
+            classes: "govuk-!-width-one-half"
+          },
+          {
+            text: 'account.pages.yourProofOfId.savedOn' | translate | replace("[date]", "02 January 2022")
+          }
+        ]
+      ]
+    }) }}
+
+    <a href="/account/settings/your-proof-of-identity/delete" class="govuk-link govuk-body">{{ 'account.pages.yourProofOfId.deleteInformationLink' | translate }}</a>
+    
+  {% else %}
+    <h2 class="govuk-heading-m">{{ 'account.pages.noSavedIdentity.heading' | translate }}</h2>
+    <p class="govuk-body">{{ 'account.pages.noSavedIdentity.paragraph1' | translate }}</p>
+
+    {{ govukButton({
+      text: "Get an Identity check now",
+      href: "/identity/prove-identity-logged-out"
+    }) }}
+
+  {% endif %}
 {% endblock %}

--- a/src/views/account/your-proof-of-identity.njk
+++ b/src/views/account/your-proof-of-identity.njk
@@ -27,7 +27,7 @@
         ],
         [
           {
-            text: "Knowlege Based Verification (KVB) Identity Check",
+            text: "Knowledge Based Verification (KBV) Identity Check",
             classes: "govuk-!-width-one-half"
           },
           {

--- a/src/views/account/your-proof-of-identity.njk
+++ b/src/views/account/your-proof-of-identity.njk
@@ -15,7 +15,7 @@
     rows: [
       [
         {
-          text: "Thing",
+          text: "Passport Based Identity Check",
           classes: "govuk-!-width-one-half"
         },
         {
@@ -24,7 +24,7 @@
       ],
       [
         {
-          text: "Thing2",
+          text: "Knowlege Based Verification (KVB) Identity Check",
           classes: "govuk-!-width-one-half"
         },
         {


### PR DESCRIPTION
## POC changes to account home area

- Place the Account area behind login
- Put a check into the "your prooved identity" area and conditionally render two templates
  1. With some hard coded content simulating the two saved checks
  2. With a page noting the user has no saved content and offering them the start of the joureny (NB not in designs!)
- Happy path links to delete button, which redirects back to "your prooved identity" after clearing the pod

An extension of this would be to populate the table dynamically from pod linked data.
This would involve adding an updated at item of RDF, and a localised string describing what the check is.

This can be a follow up "nice to have" PR as the delete portion is the key thing to demo here.