### PR TITLE
GUA-231: Connect end of IPV journey to start of service journey

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,7 +12,10 @@
   "rules": {
     "prettier/prettier": ["error"],
     "import/extensions": [1, "never"],
-    "import/no-extraneous-dependencies": ["error", {"devDependencies": ["**/*.test.ts", "**/test.ts"]}],
+    "import/no-extraneous-dependencies": [
+      "error",
+      { "devDependencies": ["**/*.test.ts", "**/test.ts"] }
+    ],
     "no-undef": ["error"],
     "no-shadow": "off",
     "no-unused-vars": "off",

--- a/src/controllers/dbs.ts
+++ b/src/controllers/dbs.ts
@@ -5,6 +5,12 @@ export async function dbsContentPageGet(
   req: Request,
   res: Response
 ): Promise<void> {
+  if (req.session) {
+    req.session.journey = {
+      nextPage: `${getHostname()}/dbs/apply-for-a-basic-dbs-check`,
+      title: "apply for a basic DBS check",
+    };
+  }
   res.render("dbs/request-a-basic-dbs-check");
 }
 

--- a/src/controllers/identity/complete.ts
+++ b/src/controllers/identity/complete.ts
@@ -2,8 +2,26 @@ import { Request, Response } from "express";
 
 export function completeSavedGet(req: Request, res: Response) {
   res.render("identity/complete/saved");
+  if (req.session) {
+    res.render("identity/complete/saved", {
+      doThing: req.session.journey.title,
+      doThingAction: req.session.journey.nextPage,
+      doThinglink: req.session.journey.nextPage,
+    });
+  }
 }
 
 export function completeReturnGet(req: Request, res: Response) {
   res.render("identity/complete/return");
+}
+
+export function identityConfirmedGet(req: Request, res: Response) {
+  if (req.session) {
+    const journeyDetails = req.session.journey;
+    delete req.session.journey;
+    res.render("identity/complete/identity-confirmed", {
+      doThing: journeyDetails.title,
+      doThingAction: journeyDetails.nextPage,
+    });
+  }
 }

--- a/src/controllers/identity/ipv.ts
+++ b/src/controllers/identity/ipv.ts
@@ -158,5 +158,10 @@ export function checkInPersonGet(req: Request, res: Response) {
 }
 
 export function useSavedProofOfIdentityGet(req: Request, res: Response) {
-  res.render("identity/use-saved-proof-of-identity");
+  if (req.session) {
+    res.render("identity/use-saved-proof-of-identity", {
+      doThing: req.session.journey.title,
+      doThingAction: req.session.journey.nextPage,
+    });
+  }
 }

--- a/src/lib/middleware/redirectIfNotLoggedIn.ts
+++ b/src/lib/middleware/redirectIfNotLoggedIn.ts
@@ -8,9 +8,6 @@ async function redirectIfNotLoggedIn(
   res: Response,
   next: NextFunction
 ) {
-  if (req.session) {
-    res.redirect("/login");
-  }
   const session = await getSessionFromStorage(req.session?.sessionId);
 
   if (!session?.info.isLoggedIn) {

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -172,6 +172,10 @@
       "heading": "Use your saved proof of identity to continue",
       "paragraph1": "You need to prove your identity before you [doThing].",
       "paragraph2": "Your GOV.UK account will check your saved proof of identity to confirm it’s really you."
+    },
+    "identityConfirmed": {
+      "heading": "Your identity has been confirmed",
+      "paragraph1": "You can now continue to [doThing]."
     }
   },
   "account": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -176,6 +176,10 @@
     "checkInPerson": {
       "heading": "Check your identity in person",
       "paragraph1": "Here is how you can do an Idenitity check in person..."
+    },
+    "identityConfirmed": {
+      "heading": "Your identity has been confirmed",
+      "paragraph1": "You can now continue to [doThing]."
     }
   },
   "account": {

--- a/src/views/dbs/apply-for-a-basic-dbs-check.njk
+++ b/src/views/dbs/apply-for-a-basic-dbs-check.njk
@@ -13,7 +13,7 @@
     <li>{{ "dbs.pages.applyForBasicCheck.listItem3" | translate }}</li>
   </ul>
   <p class="govuk-body">{{ "dbs.pages.applyForBasicCheck.paragraph3" | translate }}</p>
-  <form action="/dbs/prove-your-identity" method="post">
+  <form action="/dbs/other-names" method="get">
     {{ govukCheckboxes({
       idPrefix: "dbs-accept-privacy",
       name: "dbs-accept-privacy",

--- a/src/views/dbs/prove-your-identity.njk
+++ b/src/views/dbs/prove-your-identity.njk
@@ -7,7 +7,7 @@
   <h1 class="govuk-heading-l">{{ pageTitleName }}</h1>
   <p class="govuk-body"> {{ "dbs.pages.proveYourIdentity.paragraph1" | translate }}</p>
   <p class="govuk-body"> {{ "dbs.pages.proveYourIdentity.paragraph2" | translate }}</p>
-  <form action="/dbs/prove-your-identity" method="post">
+  <form action="/identity/prove-your-identity" method="post">
     {{ govukCheckboxes({
       idPrefix: "dbs-accept-privacy",
       name: "dbs-accept-privacy",

--- a/src/views/dbs/request-a-basic-dbs-check.njk
+++ b/src/views/dbs/request-a-basic-dbs-check.njk
@@ -45,7 +45,7 @@
 
       {{ govukButton({
         text: "Start now",
-        href: "/dbs/apply-for-a-basic-dbs-check",
+        href: "/identity/prove-identity-logged-out",
         isStartButton: true
       }) }}
     </div>

--- a/src/views/identity/complete/identity-confirmed.njk
+++ b/src/views/identity/complete/identity-confirmed.njk
@@ -1,16 +1,13 @@
 {% extends "layouts/base.njk" %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
-{% from "govuk/components/details/macro.njk" import govukDetails %}
 
 {% set pageTitleName = 'identity.useSavedIdentity.heading' | translate %}
 {% set serviceName = 'GOV.UK account' %}
 
 {% block content %}
-  <h1 class="govuk-heading-xl">{{ 'identity.useSavedIdentity.heading' | translate }}</h1>
+  <h1 class="govuk-heading-xl">{{ 'identity.identityConfirmed.heading' | translate }}</h1>
 
   <p class="govuk-body">{{ 'identity.useSavedIdentity.paragraph1' | translate | replace("[doThing]", doThing) }}</p>
-
-  <p class="govuk-body">{{ 'identity.useSavedIdentity.paragraph2' | translate }}</p>
 
   <form action="{{doThingAction}}" method="get">
     {{ govukButton({

--- a/src/views/identity/complete/saved.njk
+++ b/src/views/identity/complete/saved.njk
@@ -4,9 +4,6 @@
 
 {% set pageTitleName = 'identity.saved.heading' | translate %}
 {% set serviceName = 'GOV.UK account' %}
-{% set doThing = 'apply for a basic DBS check' %}
-{% set doThingAction = '/dbs' %}
-{% set doThingLink = '/dbs' %}
 
 {% block content %}
   <h1 class="govuk-heading-xl">{{ 'identity.saved.heading' | translate }}</h1>


### PR DESCRIPTION
This PR connects the end of the IPV journey to the beginning of the service journey that the user started from. 

When a service mock passes the user to login and IPV, it writes the service name and the URL of the next page in the service journey to the user's session. Once the user reaches the end of the IPV journey, either by answering all the questions or re-using stored checks, it reads these values back out the user's session, populates the relevant parts in the page template with the service name and sends the user back to the right place.

I've not yet set up the routing between the rest of the pages in the DBS journey, so only the first two work for now.

I got into a bit of a git mess when rebasing this onto the prettier changes, so it'd be good if the reviewer could run this branch of the app locally and step through the DBS journey twice - once with no stored checks and the second time with stored checks to make sure it's still working and the pages are in the same order as Figma.

---

[Figma](https://www.figma.com/file/f6Kn3ZhjCiiJSIQpNFt7On/Solid-example-flows?node-id=1432%3A2155)