### PR TITLE
BAU: Supress SASS warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lint": "eslint --ext .js,.ts . --max-warnings=0",
     "format": "prettier --ignore-path .prettierignore --write \"**/*.+(js|ts|json)\"",
     "clean": "rm -rf dist",
-    "build-sass": "rm -rf dist/public/stylesheets/application.css && sass --no-source-map src/public/stylesheets/application.scss dist/public/stylesheets/application.css --style compressed",
+    "build-sass": "rm -rf dist/public/stylesheets/application.css && sass --no-source-map src/public/stylesheets/application.scss dist/public/stylesheets/application.css --style compressed --quiet",
     "copy-assets": "mkdir -p dist/public/javascripts/govuk-frontend && cp node_modules/govuk-frontend/govuk/all.js dist/public/javascripts/govuk-frontend && mkdir -p dist/locales && cp -R src/locales/* dist/locales",
     "copy-views": "mkdir -p dist/views && cp -R src/views/* dist/views",
     "build": "npm run clean && npm run build-sass && npm run copy-assets && npm run copy-views && npm ci && tsc",


### PR DESCRIPTION
Government Frontend is currently supporting LibreSass and Ruby Sass
alongside Dart Sass. math.div is not available in either. So the
deprcation warning / preference does not have a clear mitigation path
until the design system is able to remove these conflicting support
requriements (aimed at October 2022, or so I hear).
Source: https://github.com/alphagov/govuk-frontend/issues/2238

In the meantime, we get a ton of noise everytime we spin up an app.

Theoretically Dart Sass (which we're using here) can silence these
errors since v1.34.0:
https://github.com/sass/dart-sass/releases/tag/1.34.0

Other folks who have encountered this have even left handy PRs we can
:eye:
https://github.com/DanCorderSoftwire/govuk-design-system-dotnet/commit/eb12d7553b865b5e7f5c4d6f428b5b7e230a54a6#diff-7bca01eb707ebcc19f259555d952675647510b2155a9a313960a8470ea0f85a6R7

However my attempts to reproduce here have not resulted in any success.
Noting the Dart docs
(https://sass-lang.com/documentation/cli/dart-sass#quiet-deps) I
expected any of the following to have an impact:

- `--load-path=node_modules --quiet-deps`
- `--load-path=node_modules/govuk-frontend --quiet-deps`

But alas no joy. I even tried shuffling them around after the `sass`
command wondering if there was something funky with flag order
precidence.

`--quiet` does change things however.

Not ideal, as I would like to know if we have errors, just not those
inherited from our deps...

On the other hand, if we did have an error right now, not sure we'd see
it through all the noise.

So... The eternal sunshine of the spotless server log? Or overkill?
Or... what's wrong with the real solution anyway?

Thought we could discuss on this PR