### PR TITLE
GUA-231: Join up end of DBS journey

### DIFF
--- a/src/controllers/dbs.ts
+++ b/src/controllers/dbs.ts
@@ -32,6 +32,10 @@ export function whatIsYourSexGet(req: Request, res: Response): void {
 }
 
 export function whatIsYourSexPost(req: Request, res: Response): void {
+  if (req.session) {
+    req.session.dbs = {};
+    req.session.dbs.sex = req.body;
+  }
   res.redirect("/dbs/where-were-you-born");
 }
 
@@ -40,6 +44,9 @@ export function whereWereYouBornGet(req: Request, res: Response): void {
 }
 
 export function whereWereYouBornPost(req: Request, res: Response): void {
+  if (req.session) {
+    req.session.dbs.whereBorn = req.body;
+  }
   res.redirect("/dbs/nino");
 }
 
@@ -48,6 +55,9 @@ export function ninoGet(req: Request, res: Response): void {
 }
 
 export function ninoPost(req: Request, res: Response): void {
+  if (req.session) {
+    req.session.dbs.nino = req.body;
+  }
   res.redirect("/dbs/driving-licence");
 }
 
@@ -56,6 +66,9 @@ export function drivingLicenceGet(req: Request, res: Response): void {
 }
 
 export function drivingLicencePost(req: Request, res: Response): void {
+  if (req.session) {
+    req.session.dbs.drivingLicence = req.body;
+  }
   res.redirect("/dbs/certificate-address-where");
 }
 
@@ -64,6 +77,9 @@ export function certificateAddressWhereGet(req: Request, res: Response): void {
 }
 
 export function certificateAddressWherePost(req: Request, res: Response): void {
+  if (req.session) {
+    req.session.dbs.certificateAddress = req.body;
+  }
   res.redirect("/dbs/email-address");
 }
 
@@ -72,6 +88,9 @@ export function emailAddressGet(req: Request, res: Response): void {
 }
 
 export function emailAddressPost(req: Request, res: Response): void {
+  if (req.session) {
+    req.session.dbs.email = req.body;
+  }
   res.redirect("/dbs/mobile-number");
 }
 
@@ -80,6 +99,9 @@ export function mobileNumberGet(req: Request, res: Response): void {
 }
 
 export function mobileNumberPost(req: Request, res: Response): void {
+  if (req.session) {
+    req.session.dbs.mobile = req.body;
+  }
   res.redirect("/dbs/who-paying");
 }
 
@@ -88,15 +110,24 @@ export function whoIsPayingGet(req: Request, res: Response): void {
 }
 
 export function whoIsPayingPost(req: Request, res: Response): void {
+  if (req.session) {
+    req.session.dbs.paying = req.body;
+  }
   res.redirect("/dbs/check-your-details");
 }
 
 export function checkYourDetailsGet(req: Request, res: Response): void {
-  res.render("dbs/check-your-details");
+  if (req.session) {
+    res.render("dbs/check-your-details", {
+      mobileNumber: req.session.dbs.mobile.number,
+      emailAddress: req.session.dbs.email.email,
+      whoPaying: req.session.dbs.paying.mobile,
+    });
+  }
 }
 
 export function checkYourDetailsPost(req: Request, res: Response): void {
-  res.render("/dbs/review-your-application");
+  res.redirect("/dbs/review-your-application");
 }
 
 export function reviewYourApplicationGet(req: Request, res: Response): void {

--- a/src/controllers/dbs.ts
+++ b/src/controllers/dbs.ts
@@ -31,42 +31,86 @@ export function whatIsYourSexGet(req: Request, res: Response): void {
   res.render("dbs/what-is-your-sex");
 }
 
+export function whatIsYourSexPost(req: Request, res: Response): void {
+  res.redirect("/dbs/where-were-you-born");
+}
+
 export function whereWereYouBornGet(req: Request, res: Response): void {
   res.render("dbs/where-were-you-born");
+}
+
+export function whereWereYouBornPost(req: Request, res: Response): void {
+  res.redirect("/dbs/nino");
 }
 
 export function ninoGet(req: Request, res: Response): void {
   res.render("dbs/nino");
 }
 
+export function ninoPost(req: Request, res: Response): void {
+  res.redirect("/dbs/driving-licence");
+}
+
 export function drivingLicenceGet(req: Request, res: Response): void {
   res.render("dbs/driving-licence");
+}
+
+export function drivingLicencePost(req: Request, res: Response): void {
+  res.redirect("/dbs/certificate-address-where");
 }
 
 export function certificateAddressWhereGet(req: Request, res: Response): void {
   res.render("dbs/certificate-address-where");
 }
 
+export function certificateAddressWherePost(req: Request, res: Response): void {
+  res.redirect("/dbs/email-address");
+}
+
 export function emailAddressGet(req: Request, res: Response): void {
   res.render("dbs/email-address");
+}
+
+export function emailAddressPost(req: Request, res: Response): void {
+  res.redirect("/dbs/mobile-number");
 }
 
 export function mobileNumberGet(req: Request, res: Response): void {
   res.render("dbs/mobile-number");
 }
 
+export function mobileNumberPost(req: Request, res: Response): void {
+  res.redirect("/dbs/who-paying");
+}
+
 export function whoIsPayingGet(req: Request, res: Response): void {
   res.render("dbs/who-paying");
+}
+
+export function whoIsPayingPost(req: Request, res: Response): void {
+  res.redirect("/dbs/check-your-details");
 }
 
 export function checkYourDetailsGet(req: Request, res: Response): void {
   res.render("dbs/check-your-details");
 }
 
+export function checkYourDetailsPost(req: Request, res: Response): void {
+  res.render("/dbs/review-your-application");
+}
+
 export function reviewYourApplicationGet(req: Request, res: Response): void {
   res.render("dbs/review-your-application");
 }
 
+export function reviewYourApplicationPost(req: Request, res: Response): void {
+  res.redirect("/dbs/disclaimer");
+}
+
 export function disclaimerGet(req: Request, res: Response): void {
+  res.render("dbs/disclaimer");
+}
+
+export function disclaimerPost(req: Request, res: Response): void {
   res.render("dbs/disclaimer");
 }

--- a/src/controllers/dbs.ts
+++ b/src/controllers/dbs.ts
@@ -1,10 +1,7 @@
 import { Request, Response } from "express";
 import { getHostname } from "../config";
 
-export async function dbsContentPageGet(
-  req: Request,
-  res: Response
-): Promise<void> {
+export function dbsContentPageGet(req: Request, res: Response): void {
   if (req.session) {
     req.session.journey = {
       nextPage: `${getHostname()}/dbs/apply-for-a-basic-dbs-check`,
@@ -14,10 +11,7 @@ export async function dbsContentPageGet(
   res.render("dbs/request-a-basic-dbs-check");
 }
 
-export async function proveYourIdentityGet(
-  req: Request,
-  res: Response
-): Promise<void> {
+export function proveYourIdentityGet(req: Request, res: Response): void {
   res.render("dbs/prove-your-identity");
 }
 
@@ -25,87 +19,54 @@ export function proveYourIdentityPost(req: Request, res: Response): void {
   res.redirect(`${getHostname()}/identity/prove-identity-logged-out`);
 }
 
-export async function applyGet(req: Request, res: Response): Promise<void> {
+export function applyGet(req: Request, res: Response): void {
   res.render("dbs/apply-for-a-basic-dbs-check");
 }
 
-export async function otherNamesGet(
-  req: Request,
-  res: Response
-): Promise<void> {
+export function otherNamesGet(req: Request, res: Response): void {
   res.render("dbs/other-names");
 }
 
-export async function whatIsYourSexGet(
-  req: Request,
-  res: Response
-): Promise<void> {
+export function whatIsYourSexGet(req: Request, res: Response): void {
   res.render("dbs/what-is-your-sex");
 }
 
-export async function whereWereYouBornGet(
-  req: Request,
-  res: Response
-): Promise<void> {
+export function whereWereYouBornGet(req: Request, res: Response): void {
   res.render("dbs/where-were-you-born");
 }
 
-export async function ninoGet(req: Request, res: Response): Promise<void> {
+export function ninoGet(req: Request, res: Response): void {
   res.render("dbs/nino");
 }
 
-export async function drivingLicenceGet(
-  req: Request,
-  res: Response
-): Promise<void> {
+export function drivingLicenceGet(req: Request, res: Response): void {
   res.render("dbs/driving-licence");
 }
 
-export async function certificateAddressWhereGet(
-  req: Request,
-  res: Response
-): Promise<void> {
+export function certificateAddressWhereGet(req: Request, res: Response): void {
   res.render("dbs/certificate-address-where");
 }
 
-export async function emailAddressGet(
-  req: Request,
-  res: Response
-): Promise<void> {
+export function emailAddressGet(req: Request, res: Response): void {
   res.render("dbs/email-address");
 }
 
-export async function mobileNumberGet(
-  req: Request,
-  res: Response
-): Promise<void> {
+export function mobileNumberGet(req: Request, res: Response): void {
   res.render("dbs/mobile-number");
 }
 
-export async function whoIsPayingGet(
-  req: Request,
-  res: Response
-): Promise<void> {
+export function whoIsPayingGet(req: Request, res: Response): void {
   res.render("dbs/who-paying");
 }
 
-export async function checkYourDetailsGet(
-  req: Request,
-  res: Response
-): Promise<void> {
+export function checkYourDetailsGet(req: Request, res: Response): void {
   res.render("dbs/check-your-details");
 }
 
-export async function reviewYourApplicationGet(
-  req: Request,
-  res: Response
-): Promise<void> {
+export function reviewYourApplicationGet(req: Request, res: Response): void {
   res.render("dbs/review-your-application");
 }
 
-export async function disclaimerGet(
-  req: Request,
-  res: Response
-): Promise<void> {
+export function disclaimerGet(req: Request, res: Response): void {
   res.render("dbs/disclaimer");
 }

--- a/src/routes/dbs.ts
+++ b/src/routes/dbs.ts
@@ -6,16 +6,27 @@ import {
   applyGet,
   otherNamesGet,
   whatIsYourSexGet,
+  whatIsYourSexPost,
   whereWereYouBornGet,
+  whereWereYouBornPost,
   ninoGet,
+  ninoPost,
   drivingLicenceGet,
+  drivingLicencePost,
   certificateAddressWhereGet,
+  certificateAddressWherePost,
   emailAddressGet,
+  emailAddressPost,
   mobileNumberGet,
+  mobileNumberPost,
   whoIsPayingGet,
+  whoIsPayingPost,
   checkYourDetailsGet,
+  checkYourDetailsPost,
   reviewYourApplicationGet,
+  reviewYourApplicationPost,
   disclaimerGet,
+  disclaimerPost,
 } from "../controllers/dbs";
 
 const router = express.Router();
@@ -26,15 +37,26 @@ router.post("/prove-your-identity", proveYourIdentityPost);
 router.get("/apply-for-a-basic-dbs-check", applyGet);
 router.get("/other-names", otherNamesGet);
 router.get("/what-is-your-sex", whatIsYourSexGet);
+router.post("/what-is-your-sex", whatIsYourSexPost);
 router.get("/where-were-you-born", whereWereYouBornGet);
+router.post("/where-were-you-born", whereWereYouBornPost);
 router.get("/nino", ninoGet);
+router.post("/nino", ninoPost);
 router.get("/driving-licence", drivingLicenceGet);
+router.post("/driving-licence", drivingLicencePost);
 router.get("/certificate-address-where", certificateAddressWhereGet);
+router.post("/certificate-address-where", certificateAddressWherePost);
 router.get("/email-address", emailAddressGet);
+router.post("/email-address", emailAddressPost);
 router.get("/mobile-number", mobileNumberGet);
+router.post("/mobile-number", mobileNumberPost);
 router.get("/who-paying", whoIsPayingGet);
+router.post("/who-paying", whoIsPayingPost);
 router.get("/check-your-details", checkYourDetailsGet);
+router.post("/check-your-details", checkYourDetailsPost);
 router.get("/review-your-application", reviewYourApplicationGet);
+router.post("/review-your-application", reviewYourApplicationPost);
 router.get("/disclaimer", disclaimerGet);
+router.post("/disclaimer", disclaimerPost);
 
 export default router;

--- a/src/views/dbs/check-your-details.njk
+++ b/src/views/dbs/check-your-details.njk
@@ -18,7 +18,7 @@
             text: "dbs.pages.checkYourDetails.mobile" | translate
           },
           value: {
-            text: "07111111111"
+            text: mobileNumber
           },
           actions: {
             items: [
@@ -35,7 +35,7 @@
             text: "dbs.pages.checkYourDetails.email" | translate
           },
           value: {
-            text: "something@something.something"
+            text: emailAddress
           },
           actions: {
             items: [
@@ -52,7 +52,7 @@
             text: "dbs.pages.checkYourDetails.payment" | translate
           },
           value: {
-            html: "-"
+            html: whoPaying
           },
           actions: {
             items: [

--- a/src/views/dbs/mobile-number.njk
+++ b/src/views/dbs/mobile-number.njk
@@ -31,7 +31,7 @@
   }) }}
 {% endset -%}
 {% block content %}
-  <form action="/dbs/mobile" method="post">
+  <form action="/dbs/mobile-number" method="post">
     {{ govukRadios({
       idPrefix: "mobile",
       name: "mobile",

--- a/src/views/dbs/other-names.njk
+++ b/src/views/dbs/other-names.njk
@@ -54,4 +54,9 @@
     ]
   }) }}
 </form>
+
+{{ govukButton({
+  text: "Continue",
+  href: "/dbs/what-is-your-sex"
+}) }}
 {% endblock %}


### PR DESCRIPTION
Allow a user to click through the pages in the DBS journey after they've proved their identity.

I wasn't completely sure where this journey should end - we have a check your details page, review your application and a disclaimer but I couldn't see a confirmation page to put after that. I've probably missed something.

I've also not populated the 'review your application' page - some of the details there need to come from the IPV journey so I'd need to implement decoding the stored checks if someone is reusing a stored identity.  We can add that functionality in a later PR if it's required.