### PR TITLE
BAU: Session fixes

### DIFF
--- a/src/controllers/identity/ipv.ts
+++ b/src/controllers/identity/ipv.ts
@@ -109,6 +109,9 @@ export function checkYourDetailsGet(req: Request, res: Response) {
 
 /* Security Question Flow */
 export function securityQuestionsIntroGet(req: Request, res: Response) {
+  if (req.session && req.session.kbv) {
+    delete req.session.kvb;
+  }
   res.render("identity/security-questions/intro");
 }
 

--- a/src/controllers/login.ts
+++ b/src/controllers/login.ts
@@ -50,3 +50,10 @@ export async function callbackGet(req: Request, res: Response): Promise<void> {
     }
   }
 }
+
+export function clearAppSessionGet(req: Request, res: Response): void {
+  if (req.session) {
+    req.session = null;
+  }
+  res.redirect("/");
+}

--- a/src/routes/login.ts
+++ b/src/routes/login.ts
@@ -1,9 +1,14 @@
 import express from "express";
-import { callbackGet, loginGet } from "../controllers/login";
+import {
+  callbackGet,
+  clearAppSessionGet,
+  loginGet,
+} from "../controllers/login";
 
 const router = express.Router();
 
 router.get("/", loginGet);
 router.get("/callback", callbackGet);
+router.get("/clear-session", clearAppSessionGet);
 
 export default router;

--- a/src/views/index.njk
+++ b/src/views/index.njk
@@ -54,4 +54,11 @@
     <li><a href="/personal-tax/home" class="govuk-link">Personal tax account home</a></li>
     <li><a href="/personal-tax/choose-paperless" class="govuk-link">Choose how to get your legal notices, penalty notices and tax letters</a></li>
   </ul>
+
+  <h3 class="govuk-heading-s">Clear app session</h2>
+
+  {{ govukButton({
+      text: "Clear app session",
+      href: "/login/clear-session"
+  }) }}
 {% endblock %}


### PR DESCRIPTION
This PR adds two small fixes / improvements to the app session in the PoC: 

1. Add a button on the homepage that sends the user to a route which clears their local app session and redirects them back to the homepage.

2. Update the KBV question state machine to clear any previous answers when a user gets to the KBV intro page.

These will make it easier to demo the PoC app