### PR TITLE
BAU: Downgrade docker image to node v16.16.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18.4.0-alpine as builder
+FROM node:16.16.0-alpine as builder
 WORKDIR /app
 COPY package.json ./
 COPY package-lock.json ./
@@ -6,7 +6,7 @@ COPY tsconfig.json ./
 COPY ./src ./src
 RUN npm ci && npm run build && rm -rf node_modules && npm ci --production
 
-FROM node:18.4.0-alpine as final
+FROM node:16.16.0-alpine as final
 WORKDIR /app
 COPY --chown=node:node --from=builder /app/package*.json ./
 COPY --chown=node:node --from=builder /app/node_modules/ node_modules


### PR DESCRIPTION
We did this in the NVMrc and I forgot about the docker image
So prod was still on v18.x