### PR TITLE
BAU: Clear 'next journey' data once used

### DIFF
--- a/src/controllers/dbs.ts
+++ b/src/controllers/dbs.ts
@@ -20,6 +20,9 @@ export function proveYourIdentityPost(req: Request, res: Response): void {
 }
 
 export function applyGet(req: Request, res: Response): void {
+  if (req.session) {
+    delete req.session.journey;
+  }
   res.render("dbs/apply-for-a-basic-dbs-check");
 }
 

--- a/src/controllers/personalTax.ts
+++ b/src/controllers/personalTax.ts
@@ -20,6 +20,9 @@ export function signInOrSetUpPost(req: Request, res: Response): void {
 }
 
 export function choosePaperlessGet(req: Request, res: Response): void {
+  if (req.session) {
+    delete req.session.journey;
+  }
   res.render("personal-tax/choose-paperless");
 }
 


### PR DESCRIPTION
Clear the `req.session.journey` object from the session once a user
has been passed back to the service journey. This will help prevent any
bugs where a user starts one service journey but not from the beginning
and then after proving their identity they are redirected to the other
service.