### PR TITLE
GUA-314: Set up the 'National Insurance number checker' service

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -20,6 +20,7 @@ import identityRouter from "./routes/identity";
 import accountRouter from "./routes/account";
 import dbsRouter from "./routes/dbs";
 import personalTaxRouter from "./routes/personalTax";
+import ninoRouter from "./routes/nino";
 
 const app: express.Application = express();
 app.use(logger("dev"));
@@ -45,6 +46,7 @@ app.use("/identity", identityRouter);
 app.use("/account", accountRouter);
 app.use("/dbs", dbsRouter);
 app.use("/personal-tax", personalTaxRouter);
+app.use("/nino", ninoRouter);
 
 i18next
   .use(Backend)

--- a/src/controllers/nino.ts
+++ b/src/controllers/nino.ts
@@ -1,6 +1,14 @@
 import { Request, Response } from "express";
+import { getHostname } from "../config";
 
 export function startGet(req: Request, res: Response): void {
+  if (req.session) {
+    const returnUri = req.params.returnUri
+      ? req.params.returnUri
+      : getHostname();
+
+    req.session.ninoReturnUri = returnUri;
+  }
   res.redirect("/nino/enter-your-number");
 }
 
@@ -25,5 +33,9 @@ export function savedNinoGet(req: Request, res: Response): void {
 }
 
 export function continueGet(req: Request, res: Response): void {
-  res.redirect("/");
+  if (req.session) {
+    res.redirect(req.session.ninoReturnUri);
+  } else {
+    res.redirect("/");
+  }
 }

--- a/src/controllers/nino.ts
+++ b/src/controllers/nino.ts
@@ -1,0 +1,9 @@
+import { Request, Response } from "express";
+
+export function enterNinoGet(req: Request, res: Response): void {
+  res.render("nino/enter-your-number");
+}
+
+export function enterNinoPost(req: Request, res: Response): void {
+  res.redirect("/nino/enter-your-number");
+}

--- a/src/controllers/nino.ts
+++ b/src/controllers/nino.ts
@@ -17,6 +17,9 @@ export function enterNinoGet(req: Request, res: Response): void {
 }
 
 export function enterNinoPost(req: Request, res: Response): void {
+  if (req.session) {
+    req.session.nino = req.body["ni-number"];
+  }
   res.redirect("/nino/weve-verified-your-number");
 }
 

--- a/src/controllers/nino.ts
+++ b/src/controllers/nino.ts
@@ -1,9 +1,29 @@
 import { Request, Response } from "express";
 
+export function startGet(req: Request, res: Response): void {
+  res.redirect("/nino/enter-your-number");
+}
+
 export function enterNinoGet(req: Request, res: Response): void {
   res.render("nino/enter-your-number");
 }
 
 export function enterNinoPost(req: Request, res: Response): void {
-  res.redirect("/nino/enter-your-number");
+  res.redirect("/nino/weve-verified-your-number");
+}
+
+export function verifiedNinoGet(req: Request, res: Response): void {
+  res.render("nino/weve-verified-your-number");
+}
+
+export function verifiedNinoPost(req: Request, res: Response): void {
+  res.redirect("/nino/youve-saved-your-number");
+}
+
+export function savedNinoGet(req: Request, res: Response): void {
+  res.render("nino/youve-saved-your-number");
+}
+
+export function continueGet(req: Request, res: Response): void {
+  res.redirect("/");
 }

--- a/src/lib/credentials.ts
+++ b/src/lib/credentials.ts
@@ -19,6 +19,8 @@ export const GOV_UK_HAS_CREDENTIAL =
 export const GOV_UK_VC_DESCRIPTION =
   "https://vocab.account.gov.uk/VCDescription";
 export const GOV_UK_VC_CREATED_AT = "https://vocab.account.gov.uk/vcCreatedAt";
+export const DWP_NATIONAL_INSURANCE_NUMBER =
+  "https://vocab.dwp.gov.uk/nationalInsuranceNumber";
 
 export function evidenceSuccessful(): IdentityCheck[] {
   return [

--- a/src/lib/nationalInsurance.ts
+++ b/src/lib/nationalInsurance.ts
@@ -1,0 +1,51 @@
+import { buildThing, createThing } from "@inrupt/solid-client";
+import type CookieSessionInterfaces from "cookie-session";
+import { RDF } from "@inrupt/vocab-common-rdf";
+
+import { Blob } from "node:buffer";
+import {
+  CheckArtifacts,
+  DWP_NATIONAL_INSURANCE_NUMBER,
+  generateJWT,
+  GOV_UK_CREDENTIAL,
+  GOV_UK_HAS_CREDENTIAL,
+  GOV_UK_VC_DESCRIPTION,
+  GOV_UK_VC_CREATED_AT,
+} from "./credentials";
+
+function buildNiNumberJWT(
+  session: CookieSessionInterfaces.CookieSessionObject
+): string {
+  const payload = {
+    nationalInsuranceNumber: session.nino,
+  };
+
+  return generateJWT(payload, session.webId);
+}
+
+export default function buildNiNumberArtifacts(
+  session: CookieSessionInterfaces.CookieSessionObject,
+  containerUri: string
+): CheckArtifacts {
+  const fileUri = `${containerUri}/ni/check`;
+  const metadataUri = `${containerUri}/ni/metadata`;
+
+  const file = new Blob([buildNiNumberJWT(session)], {
+    type: "application/json",
+  });
+
+  const metadata = buildThing(createThing({ url: metadataUri }))
+    .addUrl(RDF.type, GOV_UK_CREDENTIAL)
+    .addUrl(GOV_UK_HAS_CREDENTIAL, fileUri)
+    .addStringNoLocale(DWP_NATIONAL_INSURANCE_NUMBER, session.nino)
+    .addStringEnglish(GOV_UK_VC_DESCRIPTION, "National Insurance Number")
+    .addDatetime(GOV_UK_VC_CREATED_AT, new Date())
+    .build();
+
+  return {
+    file,
+    fileUri,
+    metadata,
+    metadataUri,
+  };
+}

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -515,6 +515,16 @@
       "enterYourNumber": {
         "title": "Enter your National Insurance number",
         "description": "We'll use this to match your National Insurance number to your proved identity."
+      },
+      "weveVerifiedYourNumber": {
+        "title": "We've verified your National Insurance number",
+        "paragraph1": "We've matched the National Insurance number you've provided to your proved identity.",
+        "paragraph2": "You can save your verified National Insurance number to your GOV.UK account. This will save you time when you use any service that needs your National Insurance number.",
+        "save": "Save your National Insurance number",
+        "continueWithoutSaving": "Or do not save and continue to personal tax account"
+      },
+      "youveSavedYourNumber": {
+        "title": "You've saved your National Insurance number to your GOV.UK account"
       }
     }
   }

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -178,13 +178,13 @@
       "paragraph1": "You need to prove your identity before you [doThing].",
       "paragraph2": "Your GOV.UK account will check your saved proof of identity to confirm it’s really you."
     },
-    "identityConfirmed": {
-      "heading": "Your identity has been confirmed",
-      "paragraph1": "You can now continue to [doThing]."
-    },
     "checkInPerson": {
       "heading": "Check your identity in person",
       "paragraph1": "Here is how you can do an Idenitity check in person..."
+    },
+    "identityConfirmed": {
+      "heading": "Your identity has been confirmed",
+      "paragraph1": "You can now continue to [doThing]."
     }
   },
   "account": {
@@ -506,6 +506,15 @@
           "heading1": "State pension",
           "paragraph1": "View your State Pension and National Insurance contributions."
         }
+      }
+    }
+  },
+  "nino": {
+    "serviceName": "National Insurance number checker",
+    "pages": {
+      "enterYourNumber": {
+        "title": "Enter your National Insurance number",
+        "description": "We'll use this to match your National Insurance number to your proved identity."
       }
     }
   }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -508,5 +508,14 @@
         }
       }
     }
+  },
+  "nino": {
+    "serviceName": "National Insurance number checker",
+    "pages": {
+      "enterYourNumber": {
+        "title": "Enter your National Insurance number",
+        "description": "We'll use this to match your National Insurance number to your proved identity."
+      }
+    }
   }
 }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -515,6 +515,16 @@
       "enterYourNumber": {
         "title": "Enter your National Insurance number",
         "description": "We'll use this to match your National Insurance number to your proved identity."
+      },
+      "weveVerifiedYourNumber": {
+        "title": "We've verified your National Insurance number",
+        "paragraph1": "We've matched the National Insurance number you've provided to your proved identity.",
+        "paragraph2": "You can save your verified National Insurance number to your GOV.UK account. This will save you time when you use any service that needs your National Insurance number.",
+        "save": "Save your National Insurance number",
+        "continueWithoutSaving": "Or do not save and continue to personal tax account"
+      },
+      "youveSavedYourNumber": {
+        "title": "You've saved your National Insurance number to your GOV.UK account"
       }
     }
   }

--- a/src/routes/nino.ts
+++ b/src/routes/nino.ts
@@ -1,4 +1,4 @@
-import express from "express";
+import express, { Request, Response, NextFunction } from "express";
 import {
   continueGet,
   enterNinoGet,
@@ -8,8 +8,13 @@ import {
   verifiedNinoPost,
   savedNinoGet,
 } from "../controllers/nino";
+import redirectIfNotLoggedIn from "../lib/middleware/redirectIfNotLoggedIn";
 
 const router = express.Router();
+
+router.use((req: Request, res: Response, next: NextFunction) => {
+  redirectIfNotLoggedIn(req, res, next);
+});
 
 router.get("/", startGet);
 router.get("/enter-your-number", enterNinoGet);

--- a/src/routes/nino.ts
+++ b/src/routes/nino.ts
@@ -1,0 +1,9 @@
+import express from "express";
+import { enterNinoGet, enterNinoPost } from "../controllers/nino";
+
+const router = express.Router();
+
+router.get("/enter-your-number", enterNinoGet);
+router.post("/enter-your-number", enterNinoPost);
+
+export default router;

--- a/src/routes/nino.ts
+++ b/src/routes/nino.ts
@@ -1,9 +1,22 @@
 import express from "express";
-import { enterNinoGet, enterNinoPost } from "../controllers/nino";
+import {
+  continueGet,
+  enterNinoGet,
+  enterNinoPost,
+  startGet,
+  verifiedNinoGet,
+  verifiedNinoPost,
+  savedNinoGet,
+} from "../controllers/nino";
 
 const router = express.Router();
 
+router.get("/", startGet);
 router.get("/enter-your-number", enterNinoGet);
 router.post("/enter-your-number", enterNinoPost);
+router.get("/weve-verified-your-number", verifiedNinoGet);
+router.post("/weve-verified-your-number", verifiedNinoPost);
+router.get("/youve-saved-your-number", savedNinoGet);
+router.get("/continue", continueGet);
 
 export default router;

--- a/src/views/nino/enter-your-number.njk
+++ b/src/views/nino/enter-your-number.njk
@@ -1,0 +1,19 @@
+{% extends "nino/layout.njk" %}
+{% set backLink = "/nino/enter-your-number" %}
+{% set pageTitleName = "nino.pages.enterYourNumber.title" | translate %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/input/macro.njk" import govukInput %}
+{% block content %}
+  <h1 class="govuk-heading-l">{{ pageTitleName }}</h1>
+  <p class="govuk-body">{{ "nino.pages.enterYourNumber.description" | translate }}</p>
+  <form action="/nino/enter-your-number" method="post">
+    {{ govukInput({
+      id: "ni-number",
+      name: "ni-number"
+    }) }}
+
+    {{ govukButton({
+      text: 'general.continue' | translate
+    }) }}
+  </form>
+{% endblock %}

--- a/src/views/nino/layout.njk
+++ b/src/views/nino/layout.njk
@@ -1,0 +1,3 @@
+{% extends "layouts/service.njk" %}
+{% set serviceName = 'nino.serviceName' | translate %}
+{% set serviceUrl = "/nino-checker" %}

--- a/src/views/nino/weve-verified-your-number.njk
+++ b/src/views/nino/weve-verified-your-number.njk
@@ -1,0 +1,18 @@
+{% extends "nino/layout.njk" %}
+{% set backLink = "/nino/enter-your-number" %}
+{% set pageTitleName = "nino.pages.enterYourNumber.title" | translate %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% block content %}
+  <h1 class="govuk-heading-l">{{ pageTitleName }}</h1>
+  <p class="govuk-body">{{ "nino.pages.weveVerifiedYourNumber.paragraph1" | translate }}</p>
+  <p class="govuk-body">{{ "nino.pages.weveVerifiedYourNumber.paragraph2" | translate }}</p>
+  <form action="/nino/weve-verified-your-number" method="post">
+    {{ govukButton({
+      text: "nino.pages.weveVerifiedYourNumber.save" | translate
+    }) }}
+  </form>
+
+  <p class="govuk-body">
+    <a class="govuk-link" href="/nino/continue">{{ "nino.pages.weveVerifiedYourNumber.continueWithoutSaving" | translate }}</a>
+  </p>
+{% endblock %}

--- a/src/views/nino/youve-saved-your-number.njk
+++ b/src/views/nino/youve-saved-your-number.njk
@@ -1,0 +1,11 @@
+{% extends "nino/layout.njk" %}
+{% set backLink = "/nino/enter-your-number" %}
+{% set pageTitleName = "nino.pages.youveSavedYourNumber.title" | translate %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% block content %}
+  <h1 class="govuk-heading-l">{{ pageTitleName }}</h1>
+  {{ govukButton({
+    text: "general.continue" | translate,
+    href: "/nino/continue"
+  }) }}
+{% endblock %}


### PR DESCRIPTION
Set up everything needed for the fake 'National Insurance number checker' service that asks a user for their National Insurance number after they've proved their identity, and saves a credential containing it back to the user's pod.

This doesn't implement the separate client ID we're expecting to need for these pages to behave like a separate service, that'll come in a later PR.

I've taken a bit of liberty here in defining the NI number as a property that's defined in a DWP-owned vocab, but it demonstrates the spirit of cross-government collaboration.