### PR TITLE
BAU: Fix title in DBS journey

### DIFF
--- a/src/views/dbs/layout.njk
+++ b/src/views/dbs/layout.njk
@@ -1,3 +1,3 @@
 {% extends "layouts/service.njk" %}
-{% set serviceName = 'personalTax.serviceName' | translate %}
-{% set serviceUrl = "/personal-tax" %}
+{% set serviceName = 'dbs.serviceName' | translate %}
+{% set serviceUrl = "/dbs" %}


### PR DESCRIPTION
Previously the service name at on the DBS pages was 'Personal tax
account' which was a bit confusing.

**Before:** 

<img width="815" alt="image" src="https://user-images.githubusercontent.com/6362602/183588435-5e5e0c9d-ff96-4f88-a969-5cac0d832cde.png">

**After:**

<img width="815" alt="image" src="https://user-images.githubusercontent.com/6362602/183588622-84502313-9455-4ab3-a685-439790929560.png">
