### PR TITLE
Added query demonstration code to Access Logs code

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,11 @@
       "name": "di-solid-prototype",
       "version": "0.0.0",
       "dependencies": {
+        "@comunica/query-sparql-solid": "^2.2.0",
         "@inrupt/solid-client": "^1.23.1",
         "@inrupt/solid-client-authn-node": "^1.12.2",
         "@inrupt/vocab-common-rdf": "^1.0.5",
+        "asynciterator": "^3.4.2",
         "cookie-parser": "~1.4.4",
         "cookie-session": "^2.0.0",
         "debug": "~4.3.4",
@@ -25,6 +27,7 @@
         "nunjucks": "^3.2.3"
       },
       "devDependencies": {
+        "@rdfjs/types": "^1.1.0",
         "@types/chai": "^4.3.3",
         "@types/cookie-parser": "^1.4.3",
         "@types/cookie-session": "^2.0.44",
@@ -60,8 +63,7 @@
     },
     "node_modules/@babel/runtime": {
       "version": "7.18.9",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.18.9.tgz",
-      "integrity": "sha512-lkqXDcvlFT5rvEjiu6+QYO+1GXrEHRo2LOtS7E4GtX5ESIZOgepqsZBVIj6Pv+a6zqsya9VCgiK1KAK4BvJDAw==",
+      "license": "MIT",
       "dependencies": {
         "regenerator-runtime": "^0.13.4"
       },
@@ -82,11 +84,1843 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@colors/colors": {
+      "version": "1.5.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
+    "node_modules/@comunica/actor-abstract-mediatyped": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0"
+      }
+    },
+    "node_modules/@comunica/actor-abstract-parse": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/core": "^2.3.0"
+      }
+    },
+    "node_modules/@comunica/actor-abstract-path": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bindings-factory": "^2.2.0",
+        "@comunica/bus-query-operation": "^2.3.0",
+        "@comunica/context-entries": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.4.2",
+        "rdf-data-factory": "^1.0.3",
+        "rdf-string": "^1.5.0",
+        "sparqlalgebrajs": "^4.0.0"
+      }
+    },
+    "node_modules/@comunica/actor-context-preprocess-source-to-destination": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-context-preprocess": "^2.3.0",
+        "@comunica/context-entries": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0"
+      }
+    },
+    "node_modules/@comunica/actor-dereference-fallback": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-dereference": "^2.3.0",
+        "@comunica/core": "^2.3.0"
+      }
+    },
+    "node_modules/@comunica/actor-dereference-http": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-dereference": "^2.3.0",
+        "@comunica/bus-http": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "cross-fetch": "^3.0.5",
+        "relative-to-absolute-iri": "^1.0.5",
+        "stream-to-string": "^1.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-dereference-rdf-parse": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-dereference": "^2.3.0",
+        "@comunica/bus-dereference-rdf": "^2.3.0",
+        "@comunica/bus-rdf-parse": "^2.3.0"
+      }
+    },
+    "node_modules/@comunica/actor-hash-bindings-sha1": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-hash-bindings": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "canonicalize": "^1.0.8",
+        "hash.js": "^1.1.7",
+        "rdf-string": "^1.5.0"
+      }
+    },
+    "node_modules/@comunica/actor-http-fetch": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-http": "^2.3.0",
+        "@comunica/context-entries": "^2.3.0",
+        "@comunica/mediatortype-time": "^2.3.0",
+        "abort-controller": "^3.0.0",
+        "cross-fetch": "^3.0.5"
+      }
+    },
+    "node_modules/@comunica/actor-http-inrupt-solid-client-authn": {
+      "version": "2.2.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-http": "^2.0.1",
+        "@comunica/context-entries": "^2.0.1",
+        "@comunica/core": "^2.0.1",
+        "@rubensworks/solid-client-authn-isomorphic": "^2.0.0"
+      }
+    },
+    "node_modules/@comunica/actor-http-proxy": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-http": "^2.3.0",
+        "@comunica/context-entries": "^2.3.0",
+        "@comunica/mediatortype-time": "^2.3.0",
+        "@comunica/types": "^2.3.0"
+      }
+    },
+    "node_modules/@comunica/actor-init-query": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/actor-http-proxy": "^2.3.0",
+        "@comunica/bus-context-preprocess": "^2.3.0",
+        "@comunica/bus-http-invalidate": "^2.3.0",
+        "@comunica/bus-init": "^2.3.0",
+        "@comunica/bus-optimize-query-operation": "^2.3.0",
+        "@comunica/bus-query-operation": "^2.3.0",
+        "@comunica/bus-query-parse": "^2.3.0",
+        "@comunica/bus-query-result-serialize": "^2.3.0",
+        "@comunica/context-entries": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/logger-pretty": "^2.3.0",
+        "@comunica/runner": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "@rdfjs/types": "*",
+        "@types/yargs": "^17.0.2",
+        "asynciterator": "^3.4.2",
+        "negotiate": "^1.0.1",
+        "rdf-quad": "^1.4.0",
+        "rdf-string": "^1.5.0",
+        "sparqlalgebrajs": "^4.0.0",
+        "streamify-string": "^1.0.1",
+        "yargs": "^17.1.1"
+      }
+    },
+    "node_modules/@comunica/actor-optimize-query-operation-bgp-to-join": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-optimize-query-operation": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "sparqlalgebrajs": "^4.0.0"
+      }
+    },
+    "node_modules/@comunica/actor-optimize-query-operation-join-bgp": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-optimize-query-operation": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "sparqlalgebrajs": "^4.0.0"
+      }
+    },
+    "node_modules/@comunica/actor-optimize-query-operation-join-connected": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-optimize-query-operation": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "sparqlalgebrajs": "^4.0.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-ask": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "sparqlalgebrajs": "^4.0.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-bgp-join": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "sparqlalgebrajs": "^4.0.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-construct": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.4.2",
+        "rdf-data-factory": "^1.0.3",
+        "rdf-terms": "^1.6.2",
+        "sparqlalgebrajs": "^4.0.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-describe-subject": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/actor-query-operation-union": "^2.3.0",
+        "@comunica/bus-query-operation": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "asynciterator": "^3.4.2",
+        "rdf-data-factory": "^1.0.3",
+        "sparqlalgebrajs": "^4.0.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-distinct-hash": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-hash-bindings": "^2.3.0",
+        "@comunica/bus-query-operation": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "sparqlalgebrajs": "^4.0.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-extend": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bindings-factory": "^2.2.0",
+        "@comunica/bus-query-operation": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "sparqlalgebrajs": "^4.0.0",
+        "sparqlee": "^2.1.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-filter-sparqlee": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bindings-factory": "^2.2.0",
+        "@comunica/bus-query-operation": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "sparqlalgebrajs": "^4.0.0",
+        "sparqlee": "^2.1.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-from-quad": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "@rdfjs/types": "*",
+        "sparqlalgebrajs": "^4.0.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-group": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bindings-factory": "^2.2.0",
+        "@comunica/bus-hash-bindings": "^2.3.0",
+        "@comunica/bus-query-operation": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.4.2",
+        "rdf-data-factory": "^1.1.0",
+        "sparqlalgebrajs": "^4.0.0",
+        "sparqlee": "^2.1.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-join": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^2.3.0",
+        "@comunica/bus-rdf-join": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "sparqlalgebrajs": "^4.0.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-leftjoin": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^2.3.0",
+        "@comunica/bus-rdf-join": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "sparqlalgebrajs": "^4.0.0",
+        "sparqlee": "^2.1.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-minus": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^2.3.0",
+        "@comunica/bus-rdf-join": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "sparqlalgebrajs": "^4.0.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-nop": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bindings-factory": "^2.2.0",
+        "@comunica/bus-query-operation": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "asynciterator": "^3.4.2",
+        "sparqlalgebrajs": "^4.0.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-orderby-sparqlee": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "asynciterator": "^3.4.2",
+        "sparqlalgebrajs": "^4.0.0",
+        "sparqlee": "^2.1.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-path-alt": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/actor-abstract-path": "^2.3.0",
+        "@comunica/actor-query-operation-union": "^2.3.0",
+        "@comunica/bus-query-operation": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "asynciterator": "^3.4.2",
+        "sparqlalgebrajs": "^4.0.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-path-inv": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/actor-abstract-path": "^2.3.0",
+        "@comunica/bus-query-operation": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "sparqlalgebrajs": "^4.0.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-path-link": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/actor-abstract-path": "^2.3.0",
+        "@comunica/bus-query-operation": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "sparqlalgebrajs": "^4.0.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-path-nps": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/actor-abstract-path": "^2.3.0",
+        "@comunica/bus-query-operation": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "sparqlalgebrajs": "^4.0.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-path-one-or-more": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/actor-abstract-path": "^2.3.0",
+        "@comunica/bindings-factory": "^2.2.0",
+        "@comunica/bus-query-operation": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "asynciterator": "^3.4.2",
+        "sparqlalgebrajs": "^4.0.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-path-seq": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/actor-abstract-path": "^2.3.0",
+        "@comunica/bus-query-operation": "^2.3.0",
+        "@comunica/bus-rdf-join": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "sparqlalgebrajs": "^4.0.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-path-zero-or-more": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/actor-abstract-path": "^2.3.0",
+        "@comunica/bindings-factory": "^2.2.0",
+        "@comunica/bus-query-operation": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "asynciterator": "^3.4.2",
+        "rdf-string": "^1.5.0",
+        "sparqlalgebrajs": "^4.0.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-path-zero-or-one": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/actor-abstract-path": "^2.3.0",
+        "@comunica/bindings-factory": "^2.2.0",
+        "@comunica/bus-query-operation": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "asynciterator": "^3.4.2",
+        "sparqlalgebrajs": "^4.0.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-project": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/data-factory": "^2.0.1",
+        "@comunica/types": "^2.3.0",
+        "@rdfjs/types": "*",
+        "rdf-data-factory": "^1.0.3",
+        "sparqlalgebrajs": "^4.0.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-quadpattern": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bindings-factory": "^2.2.0",
+        "@comunica/bus-query-operation": "^2.3.0",
+        "@comunica/bus-rdf-resolve-quad-pattern": "^2.3.0",
+        "@comunica/context-entries": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.4.2",
+        "rdf-data-factory": "^1.1.0",
+        "rdf-terms": "^1.6.2",
+        "sparqlalgebrajs": "^4.0.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-reduced-hash": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-hash-bindings": "^2.3.0",
+        "@comunica/bus-query-operation": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "@types/lru-cache": "^5.1.0",
+        "lru-cache": "^6.0.0",
+        "sparqlalgebrajs": "^4.0.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-service": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bindings-factory": "^2.2.0",
+        "@comunica/bus-query-operation": "^2.3.0",
+        "@comunica/context-entries": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "asynciterator": "^3.4.2",
+        "sparqlalgebrajs": "^4.0.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-slice": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^2.3.0",
+        "@comunica/context-entries": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "sparqlalgebrajs": "^4.0.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-sparql-endpoint": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bindings-factory": "^2.2.0",
+        "@comunica/bus-http": "^2.3.0",
+        "@comunica/bus-query-operation": "^2.3.0",
+        "@comunica/bus-rdf-resolve-quad-pattern": "^2.3.0",
+        "@comunica/bus-rdf-update-quads": "^2.3.0",
+        "@comunica/context-entries": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/mediatortype-httprequests": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.4.2",
+        "fetch-sparql-endpoint": "^2.3.2",
+        "rdf-data-factory": "^1.1.0",
+        "sparqlalgebrajs": "^4.0.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-union": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.4.2",
+        "rdf-terms": "^1.7.1",
+        "sparqlalgebrajs": "^4.0.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-update-add-rewrite": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "rdf-data-factory": "^1.0.4",
+        "sparqlalgebrajs": "^4.0.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-update-clear": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^2.3.0",
+        "@comunica/bus-rdf-update-quads": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "@rdfjs/types": "*",
+        "rdf-data-factory": "^1.0.4",
+        "sparqlalgebrajs": "^4.0.2"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-update-compositeupdate": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "sparqlalgebrajs": "^4.0.2"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-update-copy-rewrite": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "sparqlalgebrajs": "^4.0.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-update-create": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^2.3.0",
+        "@comunica/bus-rdf-update-quads": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "sparqlalgebrajs": "^4.0.2"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-update-deleteinsert": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/actor-query-operation-construct": "^2.3.0",
+        "@comunica/bindings-factory": "^2.2.0",
+        "@comunica/bus-query-operation": "^2.3.0",
+        "@comunica/bus-rdf-update-quads": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.4.2",
+        "sparqlalgebrajs": "^4.0.2"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-update-drop": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^2.3.0",
+        "@comunica/bus-rdf-update-quads": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "@rdfjs/types": "*",
+        "rdf-data-factory": "^1.0.4",
+        "sparqlalgebrajs": "^4.0.2"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-update-load": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^2.3.0",
+        "@comunica/bus-rdf-update-quads": "^2.3.0",
+        "@comunica/context-entries": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "rdf-data-factory": "^1.0.4",
+        "sparqlalgebrajs": "^4.0.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-update-move-rewrite": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "sparqlalgebrajs": "^4.0.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-values": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bindings-factory": "^2.2.0",
+        "@comunica/bus-query-operation": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "asynciterator": "^3.4.2",
+        "rdf-data-factory": "^1.1.0",
+        "sparqlalgebrajs": "^4.0.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-parse-graphql": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-query-parse": "^2.3.0",
+        "@comunica/context-entries": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "graphql-to-sparql": "^3.0.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-parse-sparql": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-query-parse": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@types/sparqljs": "^3.0.0",
+        "sparqlalgebrajs": "^4.0.0",
+        "sparqljs": "^3.4.1"
+      }
+    },
+    "node_modules/@comunica/actor-query-result-serialize-json": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-query-result-serialize": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "rdf-string": "^1.5.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-result-serialize-rdf": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-query-result-serialize": "^2.3.0",
+        "@comunica/bus-rdf-serialize": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-result-serialize-simple": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-query-result-serialize": "^2.3.0",
+        "@comunica/types": "^2.3.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-result-serialize-sparql-csv": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-query-result-serialize": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "@rdfjs/types": "*"
+      }
+    },
+    "node_modules/@comunica/actor-query-result-serialize-sparql-json": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-query-result-serialize": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "@rdfjs/types": "*"
+      }
+    },
+    "node_modules/@comunica/actor-query-result-serialize-sparql-tsv": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-query-result-serialize": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "@rdfjs/types": "*",
+        "rdf-string-ttl": "^1.1.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-result-serialize-sparql-xml": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-query-result-serialize": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "@rdfjs/types": "*",
+        "xml": "^1.0.1"
+      }
+    },
+    "node_modules/@comunica/actor-query-result-serialize-stats": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-http": "^2.3.0",
+        "@comunica/bus-query-result-serialize": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-result-serialize-table": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-query-result-serialize": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "@rdfjs/types": "*",
+        "rdf-data-factory": "^1.1.0",
+        "rdf-terms": "^1.6.2"
+      }
+    },
+    "node_modules/@comunica/actor-query-result-serialize-tree": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-query-result-serialize": "^2.3.0",
+        "@comunica/context-entries": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "sparqljson-to-tree": "^2.0.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-join-entries-sort-cardinality": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-rdf-join-entries-sort": "^2.3.0",
+        "@comunica/core": "^2.3.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-join-inner-hash": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-rdf-join": "^2.3.0",
+        "@comunica/mediatortype-join-coefficients": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "asyncjoin": "^1.0.5"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-join-inner-multi-bind": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^2.3.0",
+        "@comunica/bus-rdf-join": "^2.3.0",
+        "@comunica/bus-rdf-join-entries-sort": "^2.3.0",
+        "@comunica/context-entries": "^2.3.0",
+        "@comunica/mediatortype-join-coefficients": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "asynciterator": "^3.4.2",
+        "sparqlalgebrajs": "^4.0.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-join-inner-multi-empty": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-rdf-join": "^2.3.0",
+        "@comunica/mediatortype-join-coefficients": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "asynciterator": "^3.4.2"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-join-inner-multi-smallest": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^2.3.0",
+        "@comunica/bus-rdf-join": "^2.3.0",
+        "@comunica/bus-rdf-join-entries-sort": "^2.3.0",
+        "@comunica/mediatortype-join-coefficients": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "sparqlalgebrajs": "^4.0.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-join-inner-nestedloop": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-rdf-join": "^2.3.0",
+        "@comunica/mediatortype-join-coefficients": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "asyncjoin": "^1.0.5"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-join-inner-none": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bindings-factory": "^2.2.0",
+        "@comunica/bus-rdf-join": "^2.3.0",
+        "@comunica/mediatortype-join-coefficients": "^2.3.0",
+        "asynciterator": "^3.4.2"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-join-inner-single": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-rdf-join": "^2.3.0",
+        "@comunica/mediatortype-join-coefficients": "^2.3.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-join-inner-symmetrichash": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-rdf-join": "^2.3.0",
+        "@comunica/mediatortype-join-coefficients": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "asyncjoin": "^1.0.5"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-join-minus-hash": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-rdf-join": "^2.3.0",
+        "@comunica/mediatortype-join-coefficients": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.4.2"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-join-minus-hash-undef": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-rdf-join": "^2.3.0",
+        "@comunica/mediatortype-join-coefficients": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.4.2",
+        "rdf-string": "^1.5.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-join-optional-bind": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/actor-rdf-join-inner-multi-bind": "^2.3.0",
+        "@comunica/bus-query-operation": "^2.3.0",
+        "@comunica/bus-rdf-join": "^2.3.0",
+        "@comunica/context-entries": "^2.3.0",
+        "@comunica/mediatortype-join-coefficients": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "sparqlalgebrajs": "^4.0.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-join-optional-nestedloop": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-rdf-join": "^2.3.0",
+        "@comunica/mediatortype-join-coefficients": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "asyncjoin": "^1.0.5"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-join-selectivity-variable-counting": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-rdf-join-selectivity": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/mediatortype-accuracy": "^2.3.0",
+        "sparqlalgebrajs": "^4.0.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-metadata-all": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-rdf-metadata": "^2.3.0",
+        "@comunica/core": "^2.3.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-metadata-extract-allow-http-methods": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-rdf-metadata-extract": "^2.3.0",
+        "@comunica/core": "^2.3.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-metadata-extract-hydra-controls": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-rdf-metadata-extract": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@rdfjs/types": "*",
+        "@types/uritemplate": "^0.3.4",
+        "uritemplate": "0.3.4"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-metadata-extract-hydra-count": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-rdf-metadata-extract": "^2.3.0",
+        "@comunica/core": "^2.3.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-metadata-extract-hydra-pagesize": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-rdf-metadata-extract": "^2.3.0",
+        "@comunica/core": "^2.3.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-metadata-extract-patch-sparql-update": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-rdf-metadata-extract": "^2.3.0",
+        "@comunica/core": "^2.3.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-metadata-extract-put-accepted": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-rdf-metadata-extract": "^2.3.0",
+        "@comunica/core": "^2.3.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-metadata-extract-request-time": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-rdf-metadata-extract": "^2.3.0",
+        "@comunica/core": "^2.3.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-metadata-extract-sparql-service": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-rdf-metadata-extract": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "relative-to-absolute-iri": "^1.0.5"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-metadata-primary-topic": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-rdf-metadata": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@rdfjs/types": "*"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-html": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-rdf-parse": "^2.3.0",
+        "@comunica/bus-rdf-parse-html": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "htmlparser2": "^7.0.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-html-microdata": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-rdf-parse-html": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "microdata-rdf-streaming-parser": "^1.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-html-rdfa": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-rdf-parse-html": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "rdfa-streaming-parser": "^1.5.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-html-script": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-rdf-parse": "^2.3.0",
+        "@comunica/bus-rdf-parse-html": "^2.3.0",
+        "@comunica/context-entries": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "@rdfjs/types": "*",
+        "relative-to-absolute-iri": "^1.0.5"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-jsonld": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-http": "^2.3.0",
+        "@comunica/bus-rdf-parse": "^2.3.0",
+        "@comunica/context-entries": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "jsonld-context-parser": "^2.1.5",
+        "jsonld-streaming-parser": "^2.4.2",
+        "stream-to-string": "^1.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-n3": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-rdf-parse": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "@types/n3": "^1.4.4",
+        "n3": "^1.6.3"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-rdfxml": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-rdf-parse": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "rdfxml-streaming-parser": "^1.5.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-xml-rdfa": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-rdf-parse": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "rdfa-streaming-parser": "^1.5.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-resolve-hypermedia-links-next": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-rdf-resolve-hypermedia-links": "^2.3.0",
+        "@comunica/core": "^2.3.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-resolve-hypermedia-links-queue-fifo": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-rdf-resolve-hypermedia-links": "^2.3.0",
+        "@comunica/bus-rdf-resolve-hypermedia-links-queue": "^2.3.0",
+        "@comunica/core": "^2.3.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-resolve-hypermedia-none": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source": "^2.3.0",
+        "@comunica/bus-rdf-resolve-hypermedia": "^2.3.0",
+        "rdf-store-stream": "^1.3.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-resolve-hypermedia-qpf": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/actor-rdf-metadata-extract-hydra-controls": "^2.3.0",
+        "@comunica/bus-dereference-rdf": "^2.3.0",
+        "@comunica/bus-rdf-metadata": "^2.3.0",
+        "@comunica/bus-rdf-metadata-extract": "^2.3.0",
+        "@comunica/bus-rdf-resolve-hypermedia": "^2.3.0",
+        "@comunica/bus-rdf-resolve-quad-pattern": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.4.2",
+        "rdf-data-factory": "^1.0.3",
+        "rdf-string": "^1.5.0",
+        "rdf-terms": "^1.6.2"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-resolve-hypermedia-sparql": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bindings-factory": "^2.2.0",
+        "@comunica/bus-http": "^2.3.0",
+        "@comunica/bus-rdf-resolve-hypermedia": "^2.3.0",
+        "@comunica/bus-rdf-resolve-quad-pattern": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.4.2",
+        "fetch-sparql-endpoint": "^2.3.2",
+        "rdf-data-factory": "^1.0.3",
+        "rdf-terms": "^1.6.2",
+        "sparqlalgebrajs": "^4.0.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-resolve-quad-pattern-federated": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-rdf-resolve-quad-pattern": "^2.3.0",
+        "@comunica/context-entries": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/data-factory": "^2.0.1",
+        "@comunica/types": "^2.3.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.4.2",
+        "rdf-data-factory": "^1.0.3",
+        "rdf-terms": "^1.6.2",
+        "sparqlalgebrajs": "^4.0.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-resolve-quad-pattern-hypermedia": {
+      "version": "2.0.5",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/actor-query-result-serialize-sparql-json": "^2.0.1",
+        "@comunica/actor-rdf-metadata-extract-hydra-controls": "^2.0.1",
+        "@comunica/bus-dereference-rdf": "^2.0.2",
+        "@comunica/bus-http-invalidate": "^2.0.1",
+        "@comunica/bus-rdf-metadata": "^2.0.1",
+        "@comunica/bus-rdf-metadata-extract": "^2.0.1",
+        "@comunica/bus-rdf-resolve-hypermedia": "^2.0.1",
+        "@comunica/bus-rdf-resolve-hypermedia-links": "^2.0.1",
+        "@comunica/bus-rdf-resolve-hypermedia-links-queue": "^2.0.1",
+        "@comunica/bus-rdf-resolve-quad-pattern": "^2.0.1",
+        "@comunica/core": "^2.0.1",
+        "@comunica/types": "^2.0.1",
+        "@rdfjs/types": "*",
+        "@types/lru-cache": "^5.1.0",
+        "asynciterator": "^3.3.0",
+        "lru-cache": "^6.0.0",
+        "rdf-data-factory": "^1.0.3",
+        "rdf-string": "^1.5.0",
+        "rdf-terms": "^1.6.2",
+        "sparqlalgebrajs": "^4.0.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-rdf-resolve-quad-pattern": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.4.2"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-serialize-jsonld": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-rdf-serialize": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "jsonld-streaming-serializer": "^1.3.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-serialize-n3": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-rdf-serialize": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "n3": "^1.6.3"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-update-hypermedia-patch-sparql-update": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-http": "^2.3.0",
+        "@comunica/bus-rdf-update-hypermedia": "^2.3.0",
+        "@comunica/bus-rdf-update-quads": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.4.2",
+        "cross-fetch": "^3.0.5",
+        "rdf-string-ttl": "^1.1.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-update-hypermedia-put-ldp": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-http": "^2.3.0",
+        "@comunica/bus-rdf-serialize": "^2.3.0",
+        "@comunica/bus-rdf-update-hypermedia": "^2.3.0",
+        "@comunica/bus-rdf-update-quads": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.4.2",
+        "cross-fetch": "^3.0.5"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-update-hypermedia-sparql": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-http": "^2.3.0",
+        "@comunica/bus-rdf-update-hypermedia": "^2.3.0",
+        "@comunica/bus-rdf-update-quads": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.4.2",
+        "fetch-sparql-endpoint": "^2.3.2",
+        "rdf-string-ttl": "^1.1.0",
+        "stream-to-string": "^1.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-update-quads-hypermedia": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-dereference-rdf": "^2.3.0",
+        "@comunica/bus-http-invalidate": "^2.3.0",
+        "@comunica/bus-rdf-metadata": "^2.3.0",
+        "@comunica/bus-rdf-metadata-extract": "^2.3.0",
+        "@comunica/bus-rdf-update-hypermedia": "^2.3.0",
+        "@comunica/bus-rdf-update-quads": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "@types/lru-cache": "^5.1.0",
+        "lru-cache": "^6.0.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-update-quads-rdfjs-store": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-rdf-update-quads": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.4.2",
+        "rdf-data-factory": "^1.0.4",
+        "rdf-string": "^1.5.0"
+      }
+    },
+    "node_modules/@comunica/bindings-factory": {
+      "version": "2.2.0",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "immutable": "^4.0.0",
+        "rdf-data-factory": "^1.1.0",
+        "rdf-string": "^1.6.0"
+      }
+    },
+    "node_modules/@comunica/bus-context-preprocess": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0"
+      }
+    },
+    "node_modules/@comunica/bus-dereference": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/actor-abstract-mediatyped": "^2.3.0",
+        "@comunica/actor-abstract-parse": "^2.3.0",
+        "@comunica/context-entries": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0"
+      }
+    },
+    "node_modules/@comunica/bus-dereference-rdf": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-dereference": "^2.3.0",
+        "@comunica/bus-rdf-parse": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@rdfjs/types": "*"
+      }
+    },
+    "node_modules/@comunica/bus-hash-bindings": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0"
+      }
+    },
+    "node_modules/@comunica/bus-http": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/core": "^2.3.0",
+        "is-stream": "^2.0.0",
+        "readable-web-to-node-stream": "^3.0.2",
+        "web-streams-node": "^0.4.0"
+      }
+    },
+    "node_modules/@comunica/bus-http-invalidate": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/core": "^2.3.0"
+      }
+    },
+    "node_modules/@comunica/bus-init": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/core": "^2.3.0"
+      }
+    },
+    "node_modules/@comunica/bus-optimize-query-operation": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "sparqlalgebrajs": "^4.0.0"
+      }
+    },
+    "node_modules/@comunica/bus-query-operation": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bindings-factory": "^2.2.0",
+        "@comunica/context-entries": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/data-factory": "^2.0.1",
+        "@comunica/types": "^2.3.0",
+        "@rdfjs/types": "*",
+        "rdf-string": "^1.5.0",
+        "sparqlalgebrajs": "^4.0.0"
+      }
+    },
+    "node_modules/@comunica/bus-query-parse": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/core": "^2.3.0",
+        "@rdfjs/types": "*",
+        "sparqlalgebrajs": "^4.0.0"
+      }
+    },
+    "node_modules/@comunica/bus-query-result-serialize": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/actor-abstract-mediatyped": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0"
+      }
+    },
+    "node_modules/@comunica/bus-rdf-join": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^2.3.0",
+        "@comunica/bus-rdf-join-selectivity": "^2.3.0",
+        "@comunica/context-entries": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/mediatortype-join-coefficients": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "@rdfjs/types": "*",
+        "rdf-data-factory": "^1.1.0",
+        "rdf-string": "^1.5.0"
+      }
+    },
+    "node_modules/@comunica/bus-rdf-join-entries-sort": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0"
+      }
+    },
+    "node_modules/@comunica/bus-rdf-join-selectivity": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/core": "^2.3.0",
+        "@comunica/mediatortype-accuracy": "^2.3.0",
+        "@comunica/types": "^2.3.0"
+      }
+    },
+    "node_modules/@comunica/bus-rdf-metadata": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/core": "^2.3.0",
+        "@rdfjs/types": "*"
+      }
+    },
+    "node_modules/@comunica/bus-rdf-metadata-extract": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/core": "^2.3.0",
+        "@rdfjs/types": "*"
+      }
+    },
+    "node_modules/@comunica/bus-rdf-parse": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/actor-abstract-mediatyped": "^2.3.0",
+        "@comunica/actor-abstract-parse": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@rdfjs/types": "*"
+      }
+    },
+    "node_modules/@comunica/bus-rdf-parse-html": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/core": "^2.3.0",
+        "@rdfjs/types": "*"
+      }
+    },
+    "node_modules/@comunica/bus-rdf-resolve-hypermedia": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-rdf-resolve-quad-pattern": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@rdfjs/types": "*"
+      }
+    },
+    "node_modules/@comunica/bus-rdf-resolve-hypermedia-links": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "@rdfjs/types": "*"
+      }
+    },
+    "node_modules/@comunica/bus-rdf-resolve-hypermedia-links-queue": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-rdf-resolve-hypermedia-links": "^2.3.0",
+        "@comunica/core": "^2.3.0"
+      }
+    },
+    "node_modules/@comunica/bus-rdf-resolve-quad-pattern": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/context-entries": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.4.2",
+        "sparqlalgebrajs": "^4.0.0"
+      }
+    },
+    "node_modules/@comunica/bus-rdf-serialize": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/actor-abstract-mediatyped": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@rdfjs/types": "*"
+      }
+    },
+    "node_modules/@comunica/bus-rdf-update-hypermedia": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-rdf-update-quads": "^2.3.0",
+        "@comunica/core": "^2.3.0"
+      }
+    },
+    "node_modules/@comunica/bus-rdf-update-quads": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/actor-rdf-resolve-quad-pattern-federated": "^2.3.0",
+        "@comunica/bus-http": "^2.3.0",
+        "@comunica/context-entries": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.4.2",
+        "stream-to-string": "^1.2.0"
+      }
+    },
+    "node_modules/@comunica/config-query-sparql": {
+      "version": "2.2.0",
+      "license": "MIT"
+    },
+    "node_modules/@comunica/context-entries": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "@rdfjs/types": "*",
+        "jsonld-context-parser": "^2.1.5",
+        "sparqlalgebrajs": "^4.0.2"
+      }
+    },
+    "node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
+    "node_modules/@comunica/data-factory": {
+      "version": "2.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "*"
+      }
+    },
+    "node_modules/@comunica/logger-pretty": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/types": "^2.3.0"
+      }
+    },
+    "node_modules/@comunica/logger-void": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/types": "^2.3.0"
+      }
+    },
+    "node_modules/@comunica/mediator-all": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/core": "^2.3.0"
+      }
+    },
+    "node_modules/@comunica/mediator-combine-pipeline": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0"
+      }
+    },
+    "node_modules/@comunica/mediator-combine-union": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/core": "^2.3.0"
+      }
+    },
+    "node_modules/@comunica/mediator-join-coefficients-fixed": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-rdf-join": "^2.3.0",
+        "@comunica/context-entries": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/mediatortype-join-coefficients": "^2.3.0",
+        "@comunica/types": "^2.3.0"
+      }
+    },
+    "node_modules/@comunica/mediator-number": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/core": "^2.3.0"
+      }
+    },
+    "node_modules/@comunica/mediator-race": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/core": "^2.3.0"
+      }
+    },
+    "node_modules/@comunica/mediatortype-accuracy": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/core": "^2.3.0"
+      }
+    },
+    "node_modules/@comunica/mediatortype-httprequests": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/core": "^2.3.0"
+      }
+    },
+    "node_modules/@comunica/mediatortype-join-coefficients": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/core": "^2.3.0",
+        "@rdfjs/types": "*"
+      }
+    },
+    "node_modules/@comunica/mediatortype-time": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/core": "^2.3.0"
+      }
+    },
+    "node_modules/@comunica/query-sparql-solid": {
+      "version": "2.2.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/actor-context-preprocess-source-to-destination": "^2.0.1",
+        "@comunica/actor-dereference-fallback": "^2.0.2",
+        "@comunica/actor-dereference-http": "^2.0.2",
+        "@comunica/actor-dereference-rdf-parse": "^2.0.2",
+        "@comunica/actor-hash-bindings-sha1": "^2.0.1",
+        "@comunica/actor-http-fetch": "^2.0.1",
+        "@comunica/actor-http-inrupt-solid-client-authn": "^2.2.0",
+        "@comunica/actor-http-proxy": "^2.0.1",
+        "@comunica/actor-init-query": "^2.0.3",
+        "@comunica/actor-optimize-query-operation-bgp-to-join": "^2.0.1",
+        "@comunica/actor-optimize-query-operation-join-bgp": "^2.0.1",
+        "@comunica/actor-optimize-query-operation-join-connected": "^2.0.1",
+        "@comunica/actor-query-operation-ask": "^2.0.1",
+        "@comunica/actor-query-operation-bgp-join": "^2.0.1",
+        "@comunica/actor-query-operation-construct": "^2.0.1",
+        "@comunica/actor-query-operation-describe-subject": "^2.0.1",
+        "@comunica/actor-query-operation-distinct-hash": "^2.0.1",
+        "@comunica/actor-query-operation-extend": "^2.0.3",
+        "@comunica/actor-query-operation-filter-sparqlee": "^2.0.3",
+        "@comunica/actor-query-operation-from-quad": "^2.0.1",
+        "@comunica/actor-query-operation-group": "^2.0.3",
+        "@comunica/actor-query-operation-join": "^2.0.1",
+        "@comunica/actor-query-operation-leftjoin": "^2.0.3",
+        "@comunica/actor-query-operation-minus": "^2.0.1",
+        "@comunica/actor-query-operation-nop": "^2.0.1",
+        "@comunica/actor-query-operation-orderby-sparqlee": "^2.0.3",
+        "@comunica/actor-query-operation-path-alt": "^2.0.1",
+        "@comunica/actor-query-operation-path-inv": "^2.0.1",
+        "@comunica/actor-query-operation-path-link": "^2.0.1",
+        "@comunica/actor-query-operation-path-nps": "^2.0.1",
+        "@comunica/actor-query-operation-path-one-or-more": "^2.0.1",
+        "@comunica/actor-query-operation-path-seq": "^2.0.1",
+        "@comunica/actor-query-operation-path-zero-or-more": "^2.0.1",
+        "@comunica/actor-query-operation-path-zero-or-one": "^2.0.1",
+        "@comunica/actor-query-operation-project": "^2.0.1",
+        "@comunica/actor-query-operation-quadpattern": "^2.0.1",
+        "@comunica/actor-query-operation-reduced-hash": "^2.0.1",
+        "@comunica/actor-query-operation-service": "^2.0.1",
+        "@comunica/actor-query-operation-slice": "^2.0.1",
+        "@comunica/actor-query-operation-sparql-endpoint": "^2.0.1",
+        "@comunica/actor-query-operation-union": "^2.0.1",
+        "@comunica/actor-query-operation-update-add-rewrite": "^2.0.1",
+        "@comunica/actor-query-operation-update-clear": "^2.0.1",
+        "@comunica/actor-query-operation-update-compositeupdate": "^2.0.1",
+        "@comunica/actor-query-operation-update-copy-rewrite": "^2.0.1",
+        "@comunica/actor-query-operation-update-create": "^2.0.1",
+        "@comunica/actor-query-operation-update-deleteinsert": "^2.0.1",
+        "@comunica/actor-query-operation-update-drop": "^2.0.1",
+        "@comunica/actor-query-operation-update-load": "^2.0.1",
+        "@comunica/actor-query-operation-update-move-rewrite": "^2.0.1",
+        "@comunica/actor-query-operation-values": "^2.0.1",
+        "@comunica/actor-query-parse-graphql": "^2.0.1",
+        "@comunica/actor-query-parse-sparql": "^2.0.1",
+        "@comunica/actor-query-result-serialize-json": "^2.0.1",
+        "@comunica/actor-query-result-serialize-rdf": "^2.0.1",
+        "@comunica/actor-query-result-serialize-simple": "^2.0.1",
+        "@comunica/actor-query-result-serialize-sparql-csv": "^2.0.1",
+        "@comunica/actor-query-result-serialize-sparql-json": "^2.0.1",
+        "@comunica/actor-query-result-serialize-sparql-tsv": "^2.0.1",
+        "@comunica/actor-query-result-serialize-sparql-xml": "^2.0.1",
+        "@comunica/actor-query-result-serialize-stats": "^2.0.1",
+        "@comunica/actor-query-result-serialize-table": "^2.0.1",
+        "@comunica/actor-query-result-serialize-tree": "^2.0.1",
+        "@comunica/actor-rdf-join-entries-sort-cardinality": "^2.0.1",
+        "@comunica/actor-rdf-join-inner-hash": "^2.0.1",
+        "@comunica/actor-rdf-join-inner-multi-bind": "^2.0.1",
+        "@comunica/actor-rdf-join-inner-multi-empty": "^2.0.1",
+        "@comunica/actor-rdf-join-inner-multi-smallest": "^2.0.1",
+        "@comunica/actor-rdf-join-inner-nestedloop": "^2.0.1",
+        "@comunica/actor-rdf-join-inner-none": "^2.0.1",
+        "@comunica/actor-rdf-join-inner-single": "^2.0.1",
+        "@comunica/actor-rdf-join-inner-symmetrichash": "^2.0.1",
+        "@comunica/actor-rdf-join-minus-hash": "^2.0.1",
+        "@comunica/actor-rdf-join-minus-hash-undef": "^2.0.1",
+        "@comunica/actor-rdf-join-optional-bind": "^2.0.1",
+        "@comunica/actor-rdf-join-optional-nestedloop": "^2.0.1",
+        "@comunica/actor-rdf-join-selectivity-variable-counting": "^2.0.1",
+        "@comunica/actor-rdf-metadata-all": "^2.0.1",
+        "@comunica/actor-rdf-metadata-extract-allow-http-methods": "^2.0.1",
+        "@comunica/actor-rdf-metadata-extract-hydra-controls": "^2.0.1",
+        "@comunica/actor-rdf-metadata-extract-hydra-count": "^2.0.1",
+        "@comunica/actor-rdf-metadata-extract-hydra-pagesize": "^2.0.1",
+        "@comunica/actor-rdf-metadata-extract-patch-sparql-update": "^2.0.1",
+        "@comunica/actor-rdf-metadata-extract-put-accepted": "^2.0.1",
+        "@comunica/actor-rdf-metadata-extract-request-time": "^2.0.1",
+        "@comunica/actor-rdf-metadata-extract-sparql-service": "^2.0.1",
+        "@comunica/actor-rdf-metadata-primary-topic": "^2.0.1",
+        "@comunica/actor-rdf-parse-html": "^2.0.1",
+        "@comunica/actor-rdf-parse-html-microdata": "^2.0.1",
+        "@comunica/actor-rdf-parse-html-rdfa": "^2.0.1",
+        "@comunica/actor-rdf-parse-html-script": "^2.0.1",
+        "@comunica/actor-rdf-parse-jsonld": "^2.0.1",
+        "@comunica/actor-rdf-parse-n3": "^2.0.1",
+        "@comunica/actor-rdf-parse-rdfxml": "^2.0.1",
+        "@comunica/actor-rdf-parse-xml-rdfa": "^2.0.1",
+        "@comunica/actor-rdf-resolve-hypermedia-links-next": "^2.0.1",
+        "@comunica/actor-rdf-resolve-hypermedia-links-queue-fifo": "^2.0.1",
+        "@comunica/actor-rdf-resolve-hypermedia-none": "^2.0.1",
+        "@comunica/actor-rdf-resolve-hypermedia-qpf": "^2.0.2",
+        "@comunica/actor-rdf-resolve-hypermedia-sparql": "^2.0.1",
+        "@comunica/actor-rdf-resolve-quad-pattern-federated": "^2.0.1",
+        "@comunica/actor-rdf-resolve-quad-pattern-hypermedia": "^2.0.2",
+        "@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source": "^2.0.1",
+        "@comunica/actor-rdf-serialize-jsonld": "^2.0.1",
+        "@comunica/actor-rdf-serialize-n3": "^2.0.1",
+        "@comunica/actor-rdf-update-hypermedia-patch-sparql-update": "^2.0.1",
+        "@comunica/actor-rdf-update-hypermedia-put-ldp": "^2.0.1",
+        "@comunica/actor-rdf-update-hypermedia-sparql": "^2.0.1",
+        "@comunica/actor-rdf-update-quads-hypermedia": "^2.0.2",
+        "@comunica/actor-rdf-update-quads-rdfjs-store": "^2.0.1",
+        "@comunica/bus-http-invalidate": "^2.0.1",
+        "@comunica/config-query-sparql": "^2.0.1",
+        "@comunica/context-entries": "^2.0.1",
+        "@comunica/core": "^2.0.1",
+        "@comunica/logger-void": "^2.0.1",
+        "@comunica/mediator-all": "^2.0.1",
+        "@comunica/mediator-combine-pipeline": "^2.0.1",
+        "@comunica/mediator-combine-union": "^2.0.1",
+        "@comunica/mediator-join-coefficients-fixed": "^2.0.1",
+        "@comunica/mediator-number": "^2.0.1",
+        "@comunica/mediator-race": "^2.0.1",
+        "@comunica/runner": "^2.0.3",
+        "@comunica/runner-cli": "^2.0.3",
+        "@rubensworks/solid-client-authn-isomorphic": "^2.0.0",
+        "solid-node-interactive-auth": "^1.0.1"
+      },
+      "bin": {
+        "comunica-dynamic-sparql-solid": "bin/query-dynamic.js",
+        "comunica-sparql-solid": "bin/query.js",
+        "comunica-sparql-solid-http": "bin/http.js"
+      }
+    },
+    "node_modules/@comunica/runner": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-init": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "componentsjs": "^5.2.0"
+      },
+      "bin": {
+        "comunica-compile-config": "bin/compile-config"
+      }
+    },
+    "node_modules/@comunica/runner-cli": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-init": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/runner": "^2.3.0",
+        "@comunica/types": "^2.3.0"
+      },
+      "bin": {
+        "comunica-run": "bin/run.js"
+      }
+    },
+    "node_modules/@comunica/types": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "@types/yargs": "^17.0.2",
+        "asynciterator": "^3.4.2",
+        "sparqlalgebrajs": "^4.0.0"
+      }
+    },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
-      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "0.3.9"
       },
@@ -94,10 +1928,18 @@
         "node": ">=12"
       }
     },
+    "node_modules/@dabh/diagnostics": {
+      "version": "2.0.3",
+      "license": "MIT",
+      "dependencies": {
+        "colorspace": "1.1.x",
+        "enabled": "2.0.x",
+        "kuler": "^2.0.0"
+      }
+    },
     "node_modules/@digitalbazaar/http-client": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@digitalbazaar/http-client/-/http-client-1.2.0.tgz",
-      "integrity": "sha512-W9KQQ5pUJcaR0I4c2HPJC0a7kRbZApIorZgPnEDwMBgj16iQzutGLrCXYaZOmxqVLVNqqlQ4aUJh+HBQZy4W6Q==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "esm": "^3.2.22",
         "ky": "^0.25.1",
@@ -109,9 +1951,8 @@
     },
     "node_modules/@eslint/eslintrc": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.0.tgz",
-      "integrity": "sha512-UWW0TMTmk2d7hLcWD1/e2g5HDM/HQ3csaLSqXCfqwh4uNDuNqlaKWXmEsL4Cs41Z0KnILNvwbHAah3C2yt06kw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
@@ -129,9 +1970,8 @@
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.10.4",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.10.4.tgz",
-      "integrity": "sha512-mXAIHxZT3Vcpg83opl1wGlVZ9xydbfZO3r5YfRSH6Gpp2J/PfdBP0wbDa2sO6/qRbcalpoevVyW6A/fI6LfeMw==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@humanwhocodes/object-schema": "^1.2.1",
         "debug": "^4.1.1",
@@ -143,9 +1983,8 @@
     },
     "node_modules/@humanwhocodes/gitignore-to-minimatch": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/gitignore-to-minimatch/-/gitignore-to-minimatch-1.0.2.tgz",
-      "integrity": "sha512-rSqmMJDdLFUsyxR6FMtD00nfQKKLFb1kv+qBbOVKqErvloEIJLo5bDTJTQNTYgeyp78JsA7u/NPi5jT1GR/MuA==",
       "dev": true,
+      "license": "Apache-2.0",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
@@ -153,14 +1992,35 @@
     },
     "node_modules/@humanwhocodes/object-schema": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
-      "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
-      "dev": true
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@inrupt/oidc-client": {
+      "version": "1.11.6",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "acorn": "^7.4.1",
+        "base64-js": "^1.5.1",
+        "core-js": "^3.8.3",
+        "crypto-js": "^4.0.0",
+        "serialize-javascript": "^4.0.0"
+      }
+    },
+    "node_modules/@inrupt/oidc-client-ext": {
+      "version": "1.12.2",
+      "license": "MIT",
+      "dependencies": {
+        "@inrupt/oidc-client": "^1.11.6",
+        "@inrupt/solid-client-authn-core": "^1.12.2",
+        "@types/jest": "^27.0.3",
+        "@types/uuid": "^8.3.0",
+        "jose": "^4.3.7",
+        "uuid": "^8.3.1"
+      }
     },
     "node_modules/@inrupt/solid-client": {
       "version": "1.23.1",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-client/-/solid-client-1.23.1.tgz",
-      "integrity": "sha512-M1MyS0Qd9FjedppFctnpfAO8x046VIcmFOt9SHU3/1aDTGQrgNIqGeIBRCDwUvCRVvfvmpYE9Q9BdnA2gHAgzQ==",
+      "license": "MIT",
       "dependencies": {
         "@rdfjs/dataset": "^1.1.0",
         "@rdfjs/types": "^1.1.0",
@@ -175,10 +2035,27 @@
         "node": ">=14.0"
       }
     },
+    "node_modules/@inrupt/solid-client-authn-browser": {
+      "version": "1.12.2",
+      "license": "MIT",
+      "dependencies": {
+        "@inrupt/oidc-client-ext": "^1.12.2",
+        "@inrupt/solid-client-authn-core": "^1.12.2",
+        "@types/lodash.clonedeep": "^4.5.6",
+        "@types/node": "^18.0.3",
+        "@types/uuid": "^8.3.0",
+        "events": "^3.3.0",
+        "jose": "^4.3.7",
+        "lodash.clonedeep": "^4.5.0",
+        "uuid": "^8.3.1"
+      },
+      "engines": {
+        "node": "^14.0.0 || ^16.0.0"
+      }
+    },
     "node_modules/@inrupt/solid-client-authn-core": {
       "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-core/-/solid-client-authn-core-1.12.2.tgz",
-      "integrity": "sha512-UitzMHfUKVHy5ogYgdRLo82CUkHrFLJfnYH8jxpELEK+EzOg3zDT0vmNyNjpZ9vL9th9BOzy8RBuwWusZuo/wg==",
+      "license": "MIT",
       "dependencies": {
         "@inrupt/solid-common-vocab": "^1.0.0",
         "@types/lodash.clonedeep": "^4.5.6",
@@ -195,8 +2072,7 @@
     },
     "node_modules/@inrupt/solid-client-authn-node": {
       "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-node/-/solid-client-authn-node-1.12.2.tgz",
-      "integrity": "sha512-w7RLSMz87gJ+5xUFoH/XfKTC05kipJr5kjfJdezKrGr1RhrbLu1byPWn5iW+tfANuWtvlsXIHhEJxG7YW1Q2bQ==",
+      "license": "MIT",
       "dependencies": {
         "@inrupt/solid-client-authn-core": "^1.12.2",
         "cross-fetch": "^3.1.5",
@@ -210,37 +2086,32 @@
     },
     "node_modules/@inrupt/solid-common-vocab": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-common-vocab/-/solid-common-vocab-1.0.1.tgz",
-      "integrity": "sha512-daCb8amQHzfB9N5bop3enur6l6UHjt9/fxvC8Or9wdzybAGMSF7UcrW3Pr/MM5H0GOKrVBczlxR4t6sMWgul1g==",
+      "license": "MIT",
       "dependencies": {
         "@rdfjs/types": "^1.1.0"
       }
     },
     "node_modules/@inrupt/vocab-common-rdf": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@inrupt/vocab-common-rdf/-/vocab-common-rdf-1.0.5.tgz",
-      "integrity": "sha512-onrehQte8m0XW83WwM6T4o5WgmYGzdYUCef6FDjMKfQCF64FnARFNn5fYhKodimBaAOFKhuJ3vw1NBZV/EYqJw=="
+      "license": "MIT"
     },
     "node_modules/@jridgewell/resolve-uri": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.8.tgz",
-      "integrity": "sha512-YK5G9LaddzGbcucK4c8h5tWFmMPBvRZ/uyWmN1/SbBdIvqGUdWGkJ5BAaccgs6XbzVLsqbPJrBSFwKv3kT9i7w==",
+      "version": "3.1.0",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.4.14",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
-      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
@@ -248,9 +2119,8 @@
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
-      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
         "run-parallel": "^1.1.9"
@@ -261,18 +2131,16 @@
     },
     "node_modules/@nodelib/fs.stat": {
       "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 8"
       }
     },
     "node_modules/@nodelib/fs.walk": {
       "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
-      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
@@ -283,8 +2151,7 @@
     },
     "node_modules/@rdfjs/data-model": {
       "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/@rdfjs/data-model/-/data-model-1.3.4.tgz",
-      "integrity": "sha512-iKzNcKvJotgbFDdti7GTQDCYmL7GsGldkYStiP0K8EYtN7deJu5t7U11rKTz+nR7RtesUggT+lriZ7BakFv8QQ==",
+      "license": "MIT",
       "dependencies": {
         "@rdfjs/types": ">=1.0.1"
       },
@@ -294,8 +2161,7 @@
     },
     "node_modules/@rdfjs/dataset": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@rdfjs/dataset/-/dataset-1.1.1.tgz",
-      "integrity": "sha512-BNwCSvG0cz0srsG5esq6CQKJc1m8g/M0DZpLuiEp0MMpfwguXX7VeS8TCg4UUG3DV/DqEvhy83ZKSEjdsYseeA==",
+      "license": "MIT",
       "dependencies": {
         "@rdfjs/data-model": "^1.2.0"
       },
@@ -311,29 +2177,35 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@rubensworks/solid-client-authn-isomorphic": {
+      "version": "2.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@inrupt/solid-client-authn-browser": "^1.12.1",
+        "@inrupt/solid-client-authn-core": "^1.12.1",
+        "@inrupt/solid-client-authn-node": "^1.12.1"
+      }
+    },
     "node_modules/@sinonjs/commons": {
       "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
-      "integrity": "sha512-xkNcLAn/wZaX14RPlwizcKicDk9G3F8m2nU3L7Ukm5zBgTwiT0wsoFAHx9Jq56fJA1z/7uKGtCRu16sOUCLIHQ==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "type-detect": "4.0.8"
       }
     },
     "node_modules/@sinonjs/fake-timers": {
       "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-9.1.2.tgz",
-      "integrity": "sha512-BPS4ynJW/o92PUR4wgriz2Ud5gpST5vz6GQfMixEDK0Z8ZCUv2M7SkBLykH56T++Xs+8ln9zTGbOvNGIe02/jw==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "@sinonjs/commons": "^1.7.0"
       }
     },
     "node_modules/@sinonjs/samsam": {
       "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-6.1.1.tgz",
-      "integrity": "sha512-cZ7rKJTLiE7u7Wi/v9Hc2fs3Ucc3jrWeMgPHbbTCeVAB2S0wOBbYlkJVeNSL04i7fdhT8wIbDq1zhC/PXTD2SA==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "@sinonjs/commons": "^1.6.0",
         "lodash.get": "^4.4.2",
@@ -341,40 +2213,34 @@
       }
     },
     "node_modules/@sinonjs/text-encoding": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
-      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
-      "dev": true
+      "version": "0.7.2",
+      "dev": true,
+      "license": "(Unlicense OR Apache-2.0)"
     },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
-      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@tsconfig/node12": {
       "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
-      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@tsconfig/node14": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
-      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@tsconfig/node16": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
-      "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/body-parser": {
       "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
-      "integrity": "sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/connect": "*",
         "@types/node": "*"
@@ -388,27 +2254,24 @@
     },
     "node_modules/@types/connect": {
       "version": "3.4.35",
-      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
-      "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
     },
     "node_modules/@types/cookie-parser": {
       "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/@types/cookie-parser/-/cookie-parser-1.4.3.tgz",
-      "integrity": "sha512-CqSKwFwefj4PzZ5n/iwad/bow2hTCh0FlNAeWLtQM3JA/NX/iYagIpWG2cf1bQKQ2c9gU2log5VUCrn7LDOs0w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/express": "*"
       }
     },
     "node_modules/@types/cookie-session": {
       "version": "2.0.44",
-      "resolved": "https://registry.npmjs.org/@types/cookie-session/-/cookie-session-2.0.44.tgz",
-      "integrity": "sha512-3DheOZ41pql6raSIkqEPphJdhA2dX2bkS+s2Qacv8YMKkoCbAIEXbsDil7351ARzMqvfyDUGNeHGiRZveIzhqQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/express": "*",
         "@types/keygrip": "*"
@@ -416,9 +2279,8 @@
     },
     "node_modules/@types/express": {
       "version": "4.17.13",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
-      "integrity": "sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^4.17.18",
@@ -427,10 +2289,9 @@
       }
     },
     "node_modules/@types/express-serve-static-core": {
-      "version": "4.17.29",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.29.tgz",
-      "integrity": "sha512-uMd++6dMKS32EOuw1Uli3e3BPgdLIXmezcfHv7N4c1s3gkhikBplORPpMq3fuWkxncZN1reb16d5n8yhQ80x7Q==",
+      "version": "4.17.30",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*",
         "@types/qs": "*",
@@ -439,17 +2300,30 @@
     },
     "node_modules/@types/http-errors": {
       "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-1.8.2.tgz",
-      "integrity": "sha512-EqX+YQxINb+MeXaIqYDASb6U6FCHbWjkj4a1CKDBks3d/QiB2+PqBLyO72vLDgAO1wUI4O+9gweRcQK11bTL/w==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/http-link-header": {
+      "version": "1.0.3",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/i18next-fs-backend": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@types/i18next-fs-backend/-/i18next-fs-backend-1.1.2.tgz",
-      "integrity": "sha512-ZzTRXA5B0x0oGhzKNp08IsYjZpli4LjRZpg3q4j0XFxN5lKG2MVLnR4yHX8PPExBk4sj9Yfk1z9O6CjPrAlmIQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "i18next": "^21.0.1"
+      }
+    },
+    "node_modules/@types/jest": {
+      "version": "27.5.2",
+      "license": "MIT",
+      "dependencies": {
+        "jest-matcher-utils": "^27.0.0",
+        "pretty-format": "^27.0.0"
       }
     },
     "node_modules/@types/json-schema": {
@@ -475,48 +2349,49 @@
     },
     "node_modules/@types/keygrip": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@types/keygrip/-/keygrip-1.0.2.tgz",
-      "integrity": "sha512-GJhpTepz2udxGexqos8wgaBx4I/zWIDPh/KOGEwAqtuGDkOUJu5eFvwmdBX4AmB8Odsr+9pHCQqiAqDL/yKMKw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/lodash": {
       "version": "4.14.182",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.182.tgz",
-      "integrity": "sha512-/THyiqyQAP9AfARo4pF+aCGcyiQ94tX/Is2I7HofNRqoYLgN1PBoOWu2/zTA5zMxzP5EFutMtWtGAFRKUe961Q=="
+      "license": "MIT"
     },
     "node_modules/@types/lodash.clonedeep": {
       "version": "4.5.7",
-      "resolved": "https://registry.npmjs.org/@types/lodash.clonedeep/-/lodash.clonedeep-4.5.7.tgz",
-      "integrity": "sha512-ccNqkPptFIXrpVqUECi60/DFxjNKsfoQxSQsgcBJCX/fuX1wgyQieojkcWH/KpE3xzLoWN/2k+ZeGqIN3paSvw==",
+      "license": "MIT",
       "dependencies": {
         "@types/lodash": "*"
       }
     },
+    "node_modules/@types/lru-cache": {
+      "version": "5.1.1",
+      "license": "MIT"
+    },
     "node_modules/@types/mime": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
-      "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==",
-      "dev": true
+      "version": "3.0.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/minimist": {
+      "version": "1.2.2",
+      "license": "MIT"
     },
     "node_modules/@types/mocha": {
       "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.1.1.tgz",
-      "integrity": "sha512-Z61JK7DKDtdKTWwLeElSEBcWGRLY8g95ic5FoQqI9CMx0ns/Ghep3B4DfcEimiKMvtamNVULVNKEsiwV3aQmXw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/morgan": {
       "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/@types/morgan/-/morgan-1.9.3.tgz",
-      "integrity": "sha512-BiLcfVqGBZCyNCnCH3F4o2GmDLrpy0HeBVnNlyZG4fo88ZiE9SoiBe3C+2ezuwbjlEyT+PDZ17//TAlRxAn75Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
     },
     "node_modules/@types/n3": {
       "version": "1.10.4",
-      "resolved": "https://registry.npmjs.org/@types/n3/-/n3-1.10.4.tgz",
-      "integrity": "sha512-FfRTwcbXcScVHuAjIASveRWL6Fi6fPALl1Ge8tMESYLqU7R42LJvtdBpUi+f9YK0oQPqIN+zFFgMDFJfLMx0bg==",
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*",
         "rdf-js": "^4.0.2"
@@ -529,54 +2404,59 @@
     },
     "node_modules/@types/nunjucks": {
       "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@types/nunjucks/-/nunjucks-3.2.1.tgz",
-      "integrity": "sha512-hUh5HIC7peH+0MvlYU5KM2RydWxG1mBceivHsQGwlelU9zlczLICyJmjMwgjkI3m0+N50n46GVHkw35lIim6LQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/qs": {
       "version": "6.9.7",
-      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
-      "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/range-parser": {
       "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
-      "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/rdfjs__dataset": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@types/rdfjs__dataset/-/rdfjs__dataset-1.0.5.tgz",
-      "integrity": "sha512-8OBC9Kr/ZSgNoUTe5mHTDPHaPt8Xen4XbYfqcbYv56d+4WdKliHXaFmFc0L4I5vsynE5JGu21Hvg2zWgX1Az6Q==",
+      "license": "MIT",
       "dependencies": {
         "rdf-js": "^4.0.2"
       }
     },
-    "node_modules/@types/serve-static": {
-      "version": "1.13.10",
-      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.10.tgz",
-      "integrity": "sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==",
-      "dev": true,
+    "node_modules/@types/readable-stream": {
+      "version": "2.3.14",
+      "license": "MIT",
       "dependencies": {
-        "@types/mime": "^1",
+        "@types/node": "*",
+        "safe-buffer": "*"
+      }
+    },
+    "node_modules/@types/semver": {
+      "version": "7.3.10",
+      "license": "MIT"
+    },
+    "node_modules/@types/serve-static": {
+      "version": "1.15.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mime": "*",
         "@types/node": "*"
       }
     },
     "node_modules/@types/sinon": {
       "version": "10.0.13",
-      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-10.0.13.tgz",
-      "integrity": "sha512-UVjDqJblVNQYvVNUsj0PuYYw0ELRmgt1Nt5Vk0pT5f16ROGfcKJY8o1HVuMOJOpD727RrGB9EGvoaTQE5tgxZQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/sinonjs__fake-timers": "*"
       }
     },
     "node_modules/@types/sinon-chai": {
       "version": "3.2.8",
-      "resolved": "https://registry.npmjs.org/@types/sinon-chai/-/sinon-chai-3.2.8.tgz",
-      "integrity": "sha512-d4ImIQbT/rKMG8+AXpmcan5T2/PNeSjrYhvkwet6z0p8kzYtfgA32xzOBlbU0yqJfq+/0Ml805iFoODO0LP5/g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/chai": "*",
         "@types/sinon": "*"
@@ -584,14 +2464,38 @@
     },
     "node_modules/@types/sinonjs__fake-timers": {
       "version": "8.1.2",
-      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.2.tgz",
-      "integrity": "sha512-9GcLXF0/v3t80caGs5p2rRfkB+a8VBGLJZVih6CNFkx8IZ994wiKKLSRs9nuFwk1HevWs/1mnUmkApGrSGsShA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/spark-md5": {
+      "version": "3.0.2",
+      "license": "MIT"
+    },
+    "node_modules/@types/sparqljs": {
+      "version": "3.1.3",
+      "license": "MIT",
+      "dependencies": {
+        "rdf-js": "^4.0.2"
+      }
+    },
+    "node_modules/@types/uritemplate": {
+      "version": "0.3.4",
+      "license": "MIT"
     },
     "node_modules/@types/uuid": {
       "version": "8.3.4",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
-      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw=="
+      "license": "MIT"
+    },
+    "node_modules/@types/yargs": {
+      "version": "17.0.10",
+      "license": "MIT",
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/@types/yargs-parser": {
+      "version": "21.0.0",
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "5.33.0",
@@ -624,21 +2528,6 @@
         "typescript": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@typescript-eslint/eslint-plugin/node_modules/semver": {
-      "version": "7.3.7",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/@typescript-eslint/parser": {
@@ -751,21 +2640,6 @@
         }
       }
     },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-      "version": "7.3.7",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@typescript-eslint/utils": {
       "version": "5.33.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.33.0.tgz",
@@ -790,28 +2664,6 @@
         "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
-    "node_modules/@typescript-eslint/utils/node_modules/eslint-scope": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
-      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
-      "dev": true,
-      "dependencies": {
-        "esrecurse": "^4.3.0",
-        "estraverse": "^4.1.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@typescript-eslint/utils/node_modules/estraverse": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-      "dev": true,
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
     "node_modules/@typescript-eslint/visitor-keys": {
       "version": "5.33.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.33.0.tgz",
@@ -831,25 +2683,21 @@
     },
     "node_modules/@ungap/promise-all-settled": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
-      "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/a-sync-waterfall": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/a-sync-waterfall/-/a-sync-waterfall-1.0.1.tgz",
-      "integrity": "sha512-RYTOHHdWipFUliRFMCS4X2Yn2X8M87V/OpSqWzKKOGhzqyUxzyVmhHDH9sAvG+ZuQf/TAOFsLCpMw09I1ufUnA=="
+      "license": "MIT"
     },
     "node_modules/abbrev": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/abort-controller": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
-      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
       "dependencies": {
         "event-target-shim": "^5.0.0"
       },
@@ -859,8 +2707,7 @@
     },
     "node_modules/accepts": {
       "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
-      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
       "dependencies": {
         "mime-types": "~2.1.34",
         "negotiator": "0.6.3"
@@ -870,10 +2717,8 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
-      "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
-      "dev": true,
+      "version": "7.4.1",
+      "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -883,27 +2728,24 @@
     },
     "node_modules/acorn-jsx": {
       "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
-      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "dev": true,
+      "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/acorn-walk": {
       "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
-      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
       }
     },
     "node_modules/ajv": {
       "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -917,27 +2759,22 @@
     },
     "node_modules/ansi-colors": {
       "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
-      "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -950,9 +2787,8 @@
     },
     "node_modules/anymatch": {
       "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
-      "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
       "devOptional": true,
+      "license": "ISC",
       "dependencies": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
@@ -963,15 +2799,13 @@
     },
     "node_modules/arg": {
       "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/argparse": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
+      "dev": true,
+      "license": "Python-2.0"
     },
     "node_modules/aria-query": {
       "version": "4.2.2",
@@ -988,8 +2822,7 @@
     },
     "node_modules/array-flatten": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="
+      "license": "MIT"
     },
     "node_modules/array-includes": {
       "version": "3.1.5",
@@ -1012,9 +2845,8 @@
     },
     "node_modules/array-union": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -1057,14 +2889,12 @@
     },
     "node_modules/asap": {
       "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="
+      "license": "MIT"
     },
     "node_modules/assertion-error": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "*"
       }
@@ -1074,6 +2904,21 @@
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
       "integrity": "sha512-eBvWn1lvIApYMhzQMsu9ciLfkBY499mFZlNqG+/9WR7PVlroQw0vG30cOQQbaKz3sCEc44TAOu2ykzqXSNnwag==",
       "dev": true
+    },
+    "node_modules/async": {
+      "version": "3.2.4",
+      "license": "MIT"
+    },
+    "node_modules/asynciterator": {
+      "version": "3.6.0",
+      "license": "MIT"
+    },
+    "node_modules/asyncjoin": {
+      "version": "1.0.6",
+      "license": "MIT",
+      "dependencies": {
+        "asynciterator": "^3.2.0"
+      }
     },
     "node_modules/axe-core": {
       "version": "4.4.3",
@@ -1092,14 +2937,30 @@
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/basic-auth": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
-      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
+      "license": "MIT",
       "dependencies": {
         "safe-buffer": "5.1.2"
       },
@@ -1109,22 +2970,26 @@
     },
     "node_modules/basic-auth/node_modules/safe-buffer": {
       "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+      "license": "MIT"
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.0.2",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
-      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
       "devOptional": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/body-parser": {
       "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.0.tgz",
-      "integrity": "sha512-DfJ+q6EPcGKZD1QWUjSpqp+Q7bDQTsQIF4zfUAtZ6qk+H/3/QRhg9CEp39ss+/T2vw0+HaidC0ecJj/DRLIaKg==",
+      "license": "MIT",
       "dependencies": {
         "bytes": "3.1.2",
         "content-type": "~1.0.4",
@@ -1146,22 +3011,19 @@
     },
     "node_modules/body-parser/node_modules/debug": {
       "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
       }
     },
     "node_modules/body-parser/node_modules/ms": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -1169,9 +3031,8 @@
     },
     "node_modules/braces": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
       "devOptional": true,
+      "license": "MIT",
       "dependencies": {
         "fill-range": "^7.0.1"
       },
@@ -1181,9 +3042,8 @@
     },
     "node_modules/browser-stdout": {
       "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
-      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/buffer-equal-constant-time": {
       "version": "1.0.1",
@@ -1192,16 +3052,14 @@
     },
     "node_modules/bytes": {
       "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
-      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
     },
     "node_modules/call-bind": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.1",
         "get-intrinsic": "^1.0.2"
@@ -1212,18 +3070,16 @@
     },
     "node_modules/callsites": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/camelcase": {
       "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
-      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -1233,14 +3089,12 @@
     },
     "node_modules/canonicalize": {
       "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/canonicalize/-/canonicalize-1.0.8.tgz",
-      "integrity": "sha512-0CNTVCLZggSh7bc5VkX5WWPWO+cyZbNd07IHIsSXLia/eAq+r836hgk+8BKoEh7949Mda87VUOitx5OddVj64A=="
+      "license": "Apache-2.0"
     },
     "node_modules/chai": {
       "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.6.tgz",
-      "integrity": "sha512-bbcp3YfHCUzMOvKqsztczerVgBKSsEijCySNlHHbX3VG1nskvqjz5Rfso1gGwD6w6oOV3eI60pKuMOV5MV7p3Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "assertion-error": "^1.1.0",
         "check-error": "^1.0.2",
@@ -1256,9 +3110,7 @@
     },
     "node_modules/chalk": {
       "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -1272,17 +3124,14 @@
     },
     "node_modules/check-error": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
-      "integrity": "sha512-BrgHpW9NURQgzoNyjfq0Wu6VFO6D7IZEmJNdtgNqpzGG8RuNFHt2jQxWlAs4HMe119chBnv+34syEZtc6IhLtA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "*"
       }
     },
     "node_modules/chokidar": {
       "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
-      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
       "devOptional": true,
       "funding": [
         {
@@ -1290,6 +3139,7 @@
           "url": "https://paulmillr.com/funding/"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
@@ -1306,22 +3156,37 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/chokidar/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "devOptional": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/cliui": {
       "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
-      "dev": true,
+      "license": "ISC",
       "dependencies": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
         "wrap-ansi": "^7.0.0"
       }
     },
+    "node_modules/color": {
+      "version": "3.2.1",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^1.9.3",
+        "color-string": "^1.6.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -1331,23 +3196,76 @@
     },
     "node_modules/color-name": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
+      "license": "MIT"
+    },
+    "node_modules/color-string": {
+      "version": "1.9.1",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
+    },
+    "node_modules/color/node_modules/color-convert": {
+      "version": "1.9.3",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/color/node_modules/color-name": {
+      "version": "1.1.3",
+      "license": "MIT"
+    },
+    "node_modules/colorspace": {
+      "version": "1.1.4",
+      "license": "MIT",
+      "dependencies": {
+        "color": "^3.1.3",
+        "text-hex": "1.0.x"
+      }
     },
     "node_modules/commander": {
       "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
-      "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
+      "license": "MIT",
       "engines": {
         "node": ">= 6"
       }
     },
+    "node_modules/componentsjs": {
+      "version": "5.2.0",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "@types/minimist": "^1.2.0",
+        "@types/node": "^14.14.7",
+        "@types/semver": "^7.3.4",
+        "jsonld-context-parser": "^2.1.1",
+        "minimist": "^1.2.0",
+        "rdf-data-factory": "^1.1.0",
+        "rdf-object": "^1.13.1",
+        "rdf-parse": "^2.0.0",
+        "rdf-quad": "^1.5.0",
+        "rdf-string": "^1.6.0",
+        "rdf-terms": "^1.7.0",
+        "semver": "^7.3.2",
+        "winston": "^3.3.3"
+      },
+      "bin": {
+        "componentsjs-compile-config": "bin/compile-config.js"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/componentsjs/node_modules/@types/node": {
+      "version": "14.18.23",
+      "license": "MIT"
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/confusing-browser-globals": {
       "version": "1.0.11",
@@ -1357,8 +3275,7 @@
     },
     "node_modules/content-disposition": {
       "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
-      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
       "dependencies": {
         "safe-buffer": "5.2.1"
       },
@@ -1368,24 +3285,21 @@
     },
     "node_modules/content-type": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/cookie": {
       "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
-      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/cookie-parser": {
       "version": "1.4.6",
-      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
-      "integrity": "sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==",
+      "license": "MIT",
       "dependencies": {
         "cookie": "0.4.1",
         "cookie-signature": "1.0.6"
@@ -1396,8 +3310,7 @@
     },
     "node_modules/cookie-session": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/cookie-session/-/cookie-session-2.0.0.tgz",
-      "integrity": "sha512-hKvgoThbw00zQOleSlUr2qpvuNweoqBtxrmx0UFosx6AGi9lYtLoA+RbsvknrEX8Pr6MDbdWAb2j6SnMn+lPsg==",
+      "license": "MIT",
       "dependencies": {
         "cookies": "0.8.0",
         "debug": "3.2.7",
@@ -1410,21 +3323,18 @@
     },
     "node_modules/cookie-session/node_modules/debug": {
       "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "license": "MIT",
       "dependencies": {
         "ms": "^2.1.1"
       }
     },
     "node_modules/cookie-signature": {
       "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
+      "license": "MIT"
     },
     "node_modules/cookies": {
       "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/cookies/-/cookies-0.8.0.tgz",
-      "integrity": "sha512-8aPsApQfebXnuI+537McwYsDtjVxGm8gTIzQI3FDW6t5t/DAhERxtnbEPN/8RX+uZthoz4eCOgloXaE5cYyNow==",
+      "license": "MIT",
       "dependencies": {
         "depd": "~2.0.0",
         "keygrip": "~1.1.0"
@@ -1433,10 +3343,19 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/core-js": {
+      "version": "3.24.1",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/core-js-pure": {
-      "version": "3.24.0",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.24.0.tgz",
-      "integrity": "sha512-uzMmW8cRh7uYw4JQtzqvGWRyC2T5+4zipQLQdi2FmiRqP83k3d6F3stv2iAlNhOs6cXN401FCD5TL0vvleuHgA==",
+      "version": "3.24.1",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.24.1.tgz",
+      "integrity": "sha512-r1nJk41QLLPyozHUUPmILCEMtMw24NG4oWK6RbsDdjzQgg9ZvrUsPBj1MnG0wXXp1DCDU6j+wUvEmBSrtRbLXg==",
       "dev": true,
       "hasInstallScript": true,
       "funding": {
@@ -1446,23 +3365,20 @@
     },
     "node_modules/create-require": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cross-fetch": {
       "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
-      "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
+      "license": "MIT",
       "dependencies": {
         "node-fetch": "2.6.7"
       }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -1472,6 +3388,10 @@
         "node": ">= 8"
       }
     },
+    "node_modules/crypto-js": {
+      "version": "4.1.1",
+      "license": "MIT"
+    },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
@@ -1480,16 +3400,14 @@
     },
     "node_modules/data-uri-to-buffer": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-3.0.1.tgz",
-      "integrity": "sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og==",
+      "license": "MIT",
       "engines": {
         "node": ">= 6"
       }
     },
     "node_modules/debug": {
       "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "license": "MIT",
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -1502,16 +3420,10 @@
         }
       }
     },
-    "node_modules/debug/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-    },
     "node_modules/decamelize": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
-      "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -1521,9 +3433,8 @@
     },
     "node_modules/deep-eql": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
-      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "type-detect": "^4.0.0"
       },
@@ -1533,9 +3444,15 @@
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
-      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/define-lazy-prop": {
+      "version": "2.0.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/define-properties": {
       "version": "1.1.4",
@@ -1555,16 +3472,14 @@
     },
     "node_modules/depd": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
-      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
     },
     "node_modules/destroy": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
-      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
@@ -1572,18 +3487,23 @@
     },
     "node_modules/diff": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
-      "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
       }
     },
+    "node_modules/diff-sequences": {
+      "version": "27.5.1",
+      "license": "MIT",
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
     "node_modules/dir-glob": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
-      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "path-type": "^4.0.0"
       },
@@ -1593,14 +3513,67 @@
     },
     "node_modules/doctrine": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
-      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "esutils": "^2.0.2"
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dom-serializer": {
+      "version": "1.4.1",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.0.1",
+        "domhandler": "^4.2.0",
+        "entities": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/dom-serializer/node_modules/entities": {
+      "version": "2.2.0",
+      "license": "BSD-2-Clause",
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "4.3.1",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.2.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "2.8.0",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^1.0.1",
+        "domelementtype": "^2.2.0",
+        "domhandler": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
     "node_modules/ecdsa-sig-formatter": {
@@ -1613,21 +3586,31 @@
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
+      "license": "MIT"
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true
+      "license": "MIT"
+    },
+    "node_modules/enabled": {
+      "version": "2.0.0",
+      "license": "MIT"
     },
     "node_modules/encodeurl": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/entities": {
+      "version": "3.0.1",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-abstract": {
@@ -1695,23 +3678,19 @@
     },
     "node_modules/escalade": {
       "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
-      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/escape-html": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="
+      "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -1721,9 +3700,8 @@
     },
     "node_modules/eslint": {
       "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.21.0.tgz",
-      "integrity": "sha512-/XJ1+Qurf1T9G2M5IHrsjp+xrGT73RZf23xA1z5wB1ZzzEAWSZKvRwhWxTFp1rvkvCfwcvAUNAP31bhKTTGfDA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@eslint/eslintrc": "^1.3.0",
         "@humanwhocodes/config-array": "^0.10.4",
@@ -2131,23 +4109,31 @@
       }
     },
     "node_modules/eslint-scope": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
-      "integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
       "dev": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
-        "estraverse": "^5.2.0"
+        "estraverse": "^4.1.1"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/eslint-scope/node_modules/estraverse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/eslint-utils": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
-      "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "eslint-visitor-keys": "^2.0.0"
       },
@@ -2163,47 +4149,43 @@
     },
     "node_modules/eslint-utils/node_modules/eslint-visitor-keys": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
-      "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=10"
       }
     },
     "node_modules/eslint-visitor-keys": {
       "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
-      "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
-    "node_modules/eslint/node_modules/glob-parent": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
-      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+    "node_modules/eslint/node_modules/eslint-scope": {
+      "version": "7.1.1",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
-        "is-glob": "^4.0.3"
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
       },
       "engines": {
-        "node": ">=10.13.0"
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/esm": {
       "version": "3.2.25",
-      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
-      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/espree": {
       "version": "9.3.3",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-9.3.3.tgz",
-      "integrity": "sha512-ORs1Rt/uQTqUKjDdGCyrtYxbazf5umATSf/K4qxjmZHORR6HJk+2s/2Pqe+Kk49HHINC/xNIrGfgh8sZcll0ng==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "acorn": "^8.8.0",
         "acorn-jsx": "^5.3.2",
@@ -2216,11 +4198,21 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/espree/node_modules/acorn": {
+      "version": "8.8.0",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/esquery": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
-      "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "estraverse": "^5.1.0"
       },
@@ -2230,9 +4222,8 @@
     },
     "node_modules/esrecurse": {
       "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
-      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "estraverse": "^5.2.0"
       },
@@ -2251,41 +4242,36 @@
     },
     "node_modules/esutils": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/etag": {
       "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/event-target-shim": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/events": {
       "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
-      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.8.x"
       }
     },
     "node_modules/express": {
       "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.18.1.tgz",
-      "integrity": "sha512-zZBcOX9TfehHQhtupq57OF8lFZ3UZi08Y97dwFCkD8p9d/d2Y3M+ykKcwaMDEL+4qyUolgBDX6AblpR3fL212Q==",
+      "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -2325,30 +4311,25 @@
     },
     "node_modules/express/node_modules/cookie": {
       "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/express/node_modules/debug": {
       "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
       }
     },
     "node_modules/express/node_modules/ms": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "license": "MIT"
     },
     "node_modules/fast-diff": {
       "version": "1.2.0",
@@ -2358,9 +4339,8 @@
     },
     "node_modules/fast-glob": {
       "version": "3.2.11",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
-      "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
@@ -2372,31 +4352,42 @@
         "node": ">=8.6.0"
       }
     },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fastq": {
       "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
-      "integrity": "sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fecha": {
+      "version": "4.2.3",
+      "license": "MIT"
+    },
     "node_modules/fetch-blob": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-2.1.2.tgz",
-      "integrity": "sha512-YKqtUDwqLyfyMnmbw8XD6Q8j9i/HggKtPEI+pZ1+8bvheBu78biSmNaXWusx1TauGqtUUGx/cBb1mKdq2rLYow==",
+      "license": "MIT",
       "engines": {
         "node": "^10.17.0 || >=12.3.0"
       },
@@ -2406,11 +4397,33 @@
         }
       }
     },
+    "node_modules/fetch-sparql-endpoint": {
+      "version": "2.4.1",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "@types/readable-stream": "^2.3.11",
+        "@types/sparqljs": "^3.1.3",
+        "abort-controller": "^3.0.0",
+        "cross-fetch": "^3.0.6",
+        "is-stream": "^2.0.0",
+        "minimist": "^1.2.0",
+        "n3": "^1.6.3",
+        "rdf-string": "^1.6.0",
+        "readable-web-to-node-stream": "^3.0.2",
+        "sparqljs": "^3.1.2",
+        "sparqljson-parse": "^1.7.0",
+        "sparqlxml-parse": "^1.5.0",
+        "stream-to-string": "^1.1.0"
+      },
+      "bin": {
+        "fetch-sparql-endpoint": "bin/fetch-sparql-endpoint.js"
+      }
+    },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
-      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "flat-cache": "^3.0.4"
       },
@@ -2420,9 +4433,8 @@
     },
     "node_modules/fill-range": {
       "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
       "devOptional": true,
+      "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -2432,8 +4444,7 @@
     },
     "node_modules/finalhandler": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.0.tgz",
-      "integrity": "sha512-5uXcUVftlQMFnWC9qu/svkWv3GTd2PfUhK/3PLkYNAe7FbqJMt3515HaxE6eRL74GdsriiwujiawdaB1BpEISg==",
+      "license": "MIT",
       "dependencies": {
         "debug": "2.6.9",
         "encodeurl": "~1.0.2",
@@ -2449,22 +4460,19 @@
     },
     "node_modules/finalhandler/node_modules/debug": {
       "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
       }
     },
     "node_modules/finalhandler/node_modules/ms": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+      "license": "MIT"
     },
     "node_modules/find-up": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "locate-path": "^6.0.0",
         "path-exists": "^4.0.0"
@@ -2478,18 +4486,16 @@
     },
     "node_modules/flat": {
       "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
-      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "bin": {
         "flat": "cli.js"
       }
     },
     "node_modules/flat-cache": {
       "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
-      "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "flatted": "^3.1.0",
         "rimraf": "^3.0.2"
@@ -2500,50 +4506,35 @@
     },
     "node_modules/flatted": {
       "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.6.tgz",
-      "integrity": "sha512-0sQoMh9s0BYsm+12Huy/rkKxVu4R1+r96YX5cG44rHV0pQ6iC3Q+mkoMFaGWObMFYQxCVT+ssG1ksneA2MI9KQ==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/fn.name": {
+      "version": "1.1.0",
+      "license": "MIT"
     },
     "node_modules/forwarded": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
-      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/fresh": {
       "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "dev": true
-    },
-    "node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
       "dev": true,
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
+      "license": "ISC"
     },
     "node_modules/function-bind": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+      "license": "MIT"
     },
     "node_modules/function.prototype.name": {
       "version": "1.1.5",
@@ -2565,9 +4556,8 @@
     },
     "node_modules/functional-red-black-tree": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-      "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/functions-have-names": {
       "version": "1.2.3",
@@ -2580,26 +4570,22 @@
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true,
+      "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/get-func-name": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
-      "integrity": "sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "*"
       }
     },
     "node_modules/get-intrinsic": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.2.tgz",
-      "integrity": "sha512-Jfm3OyCxHh9DJyc28qGk+JmfkpO41A4XkneDSujN9MDXrm4oDKdHvndhZ2dN94+ERNfkYJWDclW6k2L/ZGHjXA==",
+      "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
@@ -2627,9 +4613,8 @@
     },
     "node_modules/glob": {
       "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
-      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -2646,22 +4631,20 @@
       }
     },
     "node_modules/glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "devOptional": true,
+      "version": "6.0.2",
+      "dev": true,
+      "license": "ISC",
       "dependencies": {
-        "is-glob": "^4.0.1"
+        "is-glob": "^4.0.3"
       },
       "engines": {
-        "node": ">= 6"
+        "node": ">=10.13.0"
       }
     },
     "node_modules/globals": {
-      "version": "13.15.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.15.0.tgz",
-      "integrity": "sha512-bpzcOlgDhMG070Av0Vy5Owklpv1I6+j96GhUI7Rh7IzDCKLzboflLrrfqMu8NquDbiR4EOQk7XzJwqVJxicxog==",
+      "version": "13.17.0",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "type-fest": "^0.20.2"
       },
@@ -2674,9 +4657,8 @@
     },
     "node_modules/globby": {
       "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
-      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "array-union": "^2.1.0",
         "dir-glob": "^3.0.1",
@@ -2702,14 +4684,34 @@
     },
     "node_modules/grapheme-splitter": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
-      "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/graphql": {
+      "version": "15.8.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
+    "node_modules/graphql-to-sparql": {
+      "version": "3.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "graphql": "^15.5.2",
+        "jsonld-context-parser": "^2.0.2",
+        "minimist": "^1.2.0",
+        "rdf-data-factory": "^1.1.0",
+        "sparqlalgebrajs": "^4.0.0"
+      },
+      "bin": {
+        "graphql-to-sparql": "bin/graphql-to-sparql.js"
+      }
     },
     "node_modules/has": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.1"
       },
@@ -2728,9 +4730,7 @@
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -2749,8 +4749,7 @@
     },
     "node_modules/has-symbols": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -2773,19 +4772,42 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/hash.js": {
+      "version": "1.1.7",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.1"
+      }
+    },
     "node_modules/he": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
-      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "he": "bin/he"
       }
     },
+    "node_modules/htmlparser2": {
+      "version": "7.2.0",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.0.1",
+        "domhandler": "^4.2.2",
+        "domutils": "^2.8.0",
+        "entities": "^3.0.1"
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
-      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "license": "MIT",
       "dependencies": {
         "depd": "2.0.0",
         "inherits": "2.0.4",
@@ -2799,8 +4821,7 @@
     },
     "node_modules/http-link-header": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/http-link-header/-/http-link-header-1.0.5.tgz",
-      "integrity": "sha512-msKrMbv/xHzhdOD4sstbEr+NbGqpv8ZtZliiCeByGENJo1jK1GZ/81zHF9HpWtEH5ihovPpdqHXniwZapJCKEA==",
+      "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
       }
@@ -2834,13 +4855,11 @@
     },
     "node_modules/i18next-http-middleware": {
       "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/i18next-http-middleware/-/i18next-http-middleware-3.2.1.tgz",
-      "integrity": "sha512-zBwXxDChT0YLoTXIR6jRuqnUUhXW0Iw7egoTnNXyaDRtTbfWNXwU0a53ThyuRPQ+k+tXu3ZMNKRzfLuononaRw=="
+      "license": "MIT"
     },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3"
       },
@@ -2850,30 +4869,25 @@
     },
     "node_modules/ignore": {
       "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
-      "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 4"
       }
     },
     "node_modules/ignore-by-default": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
-      "integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/immutable": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.1.0.tgz",
-      "integrity": "sha512-oNkuqVTA8jqG1Q6c+UglTOD1xhC1BtjKI7XkCXRkZHrN5m18/XsnUp8Q89GkQO/z+0WjonSvl0FLhDYftp46nQ==",
-      "dev": true
+      "license": "MIT"
     },
     "node_modules/import-fresh": {
       "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
-      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "parent-module": "^1.0.0",
         "resolve-from": "^4.0.0"
@@ -2887,18 +4901,16 @@
     },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
       }
     },
     "node_modules/inflight": {
       "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -2906,8 +4918,7 @@
     },
     "node_modules/inherits": {
       "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+      "license": "ISC"
     },
     "node_modules/internal-slot": {
       "version": "1.0.3",
@@ -2925,11 +4936,14 @@
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
-      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.3.2",
+      "license": "MIT"
     },
     "node_modules/is-bigint": {
       "version": "1.0.4",
@@ -2945,9 +4959,8 @@
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
-      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
       "devOptional": true,
+      "license": "MIT",
       "dependencies": {
         "binary-extensions": "^2.0.0"
       },
@@ -2984,9 +4997,9 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
-      "integrity": "sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.10.0.tgz",
+      "integrity": "sha512-Erxj2n/LDAZ7H8WNJXd9tw38GYM3dv8rk8Zcs+jJuxYTW7sozH+SS8NtrSjVL1/vpLvWi1hxy96IzjJ3EHTJJg==",
       "dev": true,
       "dependencies": {
         "has": "^1.0.3"
@@ -3010,29 +5023,38 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-docker": {
+      "version": "2.2.1",
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
       "devOptional": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/is-glob": {
       "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
-      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
       "devOptional": true,
+      "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
@@ -3054,9 +5076,8 @@
     },
     "node_modules/is-number": {
       "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "devOptional": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
       }
@@ -3078,9 +5099,8 @@
     },
     "node_modules/is-plain-obj": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
-      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -3111,6 +5131,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-string": {
@@ -3145,9 +5175,8 @@
     },
     "node_modules/is-unicode-supported": {
       "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
-      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -3167,22 +5196,62 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-wsl": {
+      "version": "2.2.0",
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/isarray": {
       "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/jest-diff": {
+      "version": "27.5.1",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "diff-sequences": "^27.5.1",
+        "jest-get-type": "^27.5.1",
+        "pretty-format": "^27.5.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/jest-get-type": {
+      "version": "27.5.1",
+      "license": "MIT",
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/jest-matcher-utils": {
+      "version": "27.5.1",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "jest-diff": "^27.5.1",
+        "jest-get-type": "^27.5.1",
+        "pretty-format": "^27.5.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
     },
     "node_modules/jose": {
       "version": "4.8.3",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-4.8.3.tgz",
-      "integrity": "sha512-7rySkpW78d8LBp4YU70Wb7+OTgE3OwAALNVZxhoIhp4Kscp+p/fBkdpxGAMKxvCAMV4QfXBU9m6l9nX/vGwd2g==",
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -3195,9 +5264,8 @@
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -3207,15 +5275,13 @@
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/json5": {
       "version": "1.0.1",
@@ -3231,8 +5297,7 @@
     },
     "node_modules/jsonld": {
       "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/jsonld/-/jsonld-5.2.0.tgz",
-      "integrity": "sha512-JymgT6Xzk5CHEmHuEyvoTNviEPxv6ihLWSPu1gFdtjSAyM6cFqNrv02yS/SIur3BBIkCf0HjizRc24d8/FfQKw==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "@digitalbazaar/http-client": "^1.1.0",
         "canonicalize": "^1.0.1",
@@ -3241,6 +5306,63 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/jsonld-context-parser": {
+      "version": "2.2.0",
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-link-header": "^1.0.1",
+        "@types/node": "^18.0.0",
+        "canonicalize": "^1.0.1",
+        "cross-fetch": "^3.0.6",
+        "http-link-header": "^1.0.2",
+        "relative-to-absolute-iri": "^1.0.5"
+      },
+      "bin": {
+        "jsonld-context-parse": "bin/jsonld-context-parse.js"
+      }
+    },
+    "node_modules/jsonld-streaming-parser": {
+      "version": "2.4.3",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "@types/http-link-header": "^1.0.1",
+        "canonicalize": "^1.0.1",
+        "http-link-header": "^1.0.2",
+        "jsonld-context-parser": "^2.1.3",
+        "jsonparse": "^1.3.1",
+        "rdf-data-factory": "^1.1.0"
+      }
+    },
+    "node_modules/jsonld-streaming-serializer": {
+      "version": "1.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "jsonld-context-parser": "^2.0.0"
+      }
+    },
+    "node_modules/jsonparse": {
+      "version": "1.3.1",
+      "engines": [
+        "node >= 0.2.0"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/JSONStream": {
+      "version": "1.3.5",
+      "license": "(MIT OR Apache-2.0)",
+      "dependencies": {
+        "jsonparse": "^1.2.0",
+        "through": ">=2.2.7 <3"
+      },
+      "bin": {
+        "JSONStream": "bin.js"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/jsonwebtoken": {
@@ -3273,13 +5395,13 @@
       }
     },
     "node_modules/jsx-ast-utils": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.2.tgz",
-      "integrity": "sha512-4ZCADZHRkno244xlNnn4AOG6sRQ7iBZ5BbgZ4vW4y5IZw7cVUD1PPeblm1xx/nfmMxPdt/LHsXZW8z/j58+l9Q==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.3.tgz",
+      "integrity": "sha512-fYQHZTZ8jSfmWZ0iyzfwiU4WDX4HpHbMCZ3gPlWYiCl3BoeOTsqKBqnTVfH2rYT7eP5c3sVbeSPHnnJOaTrWiw==",
       "dev": true,
       "dependencies": {
         "array-includes": "^3.1.5",
-        "object.assign": "^4.1.2"
+        "object.assign": "^4.1.3"
       },
       "engines": {
         "node": ">=4.0"
@@ -3287,9 +5409,8 @@
     },
     "node_modules/just-extend": {
       "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
-      "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/jwa": {
       "version": "1.4.1",
@@ -3312,8 +5433,7 @@
     },
     "node_modules/keygrip": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/keygrip/-/keygrip-1.1.0.tgz",
-      "integrity": "sha512-iYSchDJ+liQ8iwbSI2QqsQOvqv58eJCEanyJPJi+Khyu8smkcKSFUCbPwzFcL7YVtZ6eONjqRX/38caJ7QjRAQ==",
+      "license": "MIT",
       "dependencies": {
         "tsscmp": "1.0.6"
       },
@@ -3321,10 +5441,13 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/kuler": {
+      "version": "2.0.0",
+      "license": "MIT"
+    },
     "node_modules/ky": {
       "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/ky/-/ky-0.25.1.tgz",
-      "integrity": "sha512-PjpCEWlIU7VpiMVrTwssahkYXX1by6NCT0fhTUX34F3DTinARlgMpriuroolugFPcMgpPWrOW4mTb984Qm1RXA==",
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -3334,8 +5457,7 @@
     },
     "node_modules/ky-universal": {
       "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/ky-universal/-/ky-universal-0.8.2.tgz",
-      "integrity": "sha512-xe0JaOH9QeYxdyGLnzUOVGK4Z6FGvDVzcXFTdrYA1f33MZdEa45sUDaMBy98xQMcsd2XIBrTXRrRYnegcSdgVQ==",
+      "license": "MIT",
       "dependencies": {
         "abort-controller": "^3.0.0",
         "node-fetch": "3.0.0-beta.9"
@@ -3358,8 +5480,7 @@
     },
     "node_modules/ky-universal/node_modules/node-fetch": {
       "version": "3.0.0-beta.9",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.0.0-beta.9.tgz",
-      "integrity": "sha512-RdbZCEynH2tH46+tj0ua9caUHVWrd/RHnRfvly2EVdqGmI3ndS1Vn/xjm5KuGejDt2RNDQsVRLPNd2QPwcewVg==",
+      "license": "MIT",
       "dependencies": {
         "data-uri-to-buffer": "^3.0.1",
         "fetch-blob": "^2.1.1"
@@ -3389,9 +5510,8 @@
     },
     "node_modules/levn": {
       "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
-      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "prelude-ls": "^1.2.1",
         "type-check": "~0.4.0"
@@ -3402,9 +5522,8 @@
     },
     "node_modules/locate-path": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "p-locate": "^5.0.0"
       },
@@ -3417,14 +5536,12 @@
     },
     "node_modules/lodash.clonedeep": {
       "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ=="
+      "license": "MIT"
     },
     "node_modules/lodash.get": {
       "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
@@ -3458,9 +5575,8 @@
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lodash.once": {
       "version": "4.1.1",
@@ -3469,9 +5585,8 @@
     },
     "node_modules/log-symbols": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
-      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.0",
         "is-unicode-supported": "^0.1.0"
@@ -3481,6 +5596,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/logform": {
+      "version": "2.4.2",
+      "license": "MIT",
+      "dependencies": {
+        "@colors/colors": "1.5.0",
+        "fecha": "^4.2.0",
+        "ms": "^2.1.1",
+        "safe-stable-stringify": "^2.3.1",
+        "triple-beam": "^1.3.0"
       }
     },
     "node_modules/loose-envify": {
@@ -3497,17 +5623,15 @@
     },
     "node_modules/loupe": {
       "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.4.tgz",
-      "integrity": "sha512-OvKfgCC2Ndby6aSTREl5aCCPTNIzlDfQZvZxNUrBrihDhL3xcrYegTblhmEiCrg2kKQz4XsFIaemE5BF4ybSaQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "get-func-name": "^2.0.0"
       }
     },
     "node_modules/lru-cache": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "license": "ISC",
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -3517,45 +5641,73 @@
     },
     "node_modules/make-error": {
       "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/media-typer": {
       "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/merge-descriptors": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-      "integrity": "sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w=="
+      "license": "MIT"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 8"
       }
     },
     "node_modules/methods": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
     },
+    "node_modules/microdata-rdf-streaming-parser": {
+      "version": "1.2.0",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "htmlparser2": "^6.0.0",
+        "rdf-data-factory": "^1.1.0",
+        "relative-to-absolute-iri": "^1.0.2"
+      }
+    },
+    "node_modules/microdata-rdf-streaming-parser/node_modules/entities": {
+      "version": "2.2.0",
+      "license": "BSD-2-Clause",
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/microdata-rdf-streaming-parser/node_modules/htmlparser2": {
+      "version": "6.1.0",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.0.1",
+        "domhandler": "^4.0.0",
+        "domutils": "^2.5.2",
+        "entities": "^2.0.0"
+      }
+    },
     "node_modules/micromatch": {
       "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "braces": "^3.0.2",
         "picomatch": "^2.3.1"
@@ -3566,8 +5718,7 @@
     },
     "node_modules/mime": {
       "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
       "bin": {
         "mime": "cli.js"
       },
@@ -3577,16 +5728,14 @@
     },
     "node_modules/mime-db": {
       "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/mime-types": {
       "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -3594,11 +5743,14 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "license": "ISC"
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -3608,15 +5760,12 @@
     },
     "node_modules/minimist": {
       "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
-      "dev": true
+      "license": "MIT"
     },
     "node_modules/mocha": {
       "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.0.0.tgz",
-      "integrity": "sha512-0Wl+elVUD43Y0BqPZBzZt8Tnkw9CMUdNYnUsTfOM1vuhJVZL+kiesFYsqwBkEEuEixaiPe5ZQdqDgX2jddhmoA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@ungap/promise-all-settled": "1.1.2",
         "ansi-colors": "4.1.1",
@@ -3655,18 +5804,16 @@
     },
     "node_modules/mocha/node_modules/brace-expansion": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
     },
     "node_modules/mocha/node_modules/minimatch": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
-      "integrity": "sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -3674,11 +5821,23 @@
         "node": ">=10"
       }
     },
+    "node_modules/mocha/node_modules/ms": {
+      "version": "2.1.3",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mocha/node_modules/serialize-javascript": {
+      "version": "6.0.0",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "randombytes": "^2.1.0"
+      }
+    },
     "node_modules/mocha/node_modules/supports-color": {
       "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -3689,10 +5848,26 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/mocha/node_modules/yargs": {
+      "version": "16.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/morgan": {
       "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.0.tgz",
-      "integrity": "sha512-AbegBVI4sh6El+1gNwvD5YIck7nSA36weD7xvIxG4in80j/UoK8AEGaWnnz8v1GxonMCltmlNs5ZKbGvl9b1XQ==",
+      "license": "MIT",
       "dependencies": {
         "basic-auth": "~2.0.1",
         "debug": "2.6.9",
@@ -3706,21 +5881,18 @@
     },
     "node_modules/morgan/node_modules/debug": {
       "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
       }
     },
     "node_modules/morgan/node_modules/ms": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+      "license": "MIT"
     },
     "node_modules/morgan/node_modules/on-finished": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-      "integrity": "sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==",
+      "license": "MIT",
       "dependencies": {
         "ee-first": "1.1.1"
       },
@@ -3729,14 +5901,12 @@
       }
     },
     "node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+      "version": "2.1.2",
+      "license": "MIT"
     },
     "node_modules/n3": {
       "version": "1.16.2",
-      "resolved": "https://registry.npmjs.org/n3/-/n3-1.16.2.tgz",
-      "integrity": "sha512-5vYa2HuNEJ+a26FEs4FGgfFLgaPOODaZpJlc7FS0eUjDumc4uK0cvx216PjKXBkLzmAsSqGgQPwqztcLLvwDsw==",
+      "license": "MIT",
       "dependencies": {
         "queue-microtask": "^1.1.2",
         "readable-stream": "^3.6.0"
@@ -3747,9 +5917,8 @@
     },
     "node_modules/nanoid": {
       "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.3.tgz",
-      "integrity": "sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -3759,23 +5928,23 @@
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/negotiate": {
+      "version": "1.0.1"
     },
     "node_modules/negotiator": {
       "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
-      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/nise": {
       "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.1.tgz",
-      "integrity": "sha512-yr5kW2THW1AkxVmCnKEh4nbYkJdB3I7LUkiUgOvEkOp414mc2UMaHMA7pjq1nYowhdoJZGwEKGaQVbxfpWj10A==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "@sinonjs/commons": "^1.8.3",
         "@sinonjs/fake-timers": ">=5",
@@ -3786,17 +5955,15 @@
     },
     "node_modules/nise/node_modules/path-to-regexp": {
       "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
-      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "isarray": "0.0.1"
       }
     },
     "node_modules/node-fetch": {
       "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "license": "MIT",
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -3814,10 +5981,9 @@
     },
     "node_modules/nodemon": {
       "version": "2.0.19",
-      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-2.0.19.tgz",
-      "integrity": "sha512-4pv1f2bMDj0Eeg/MhGqxrtveeQ5/G/UVe9iO6uTZzjnRluSA4PVWf8CW99LUPwGB3eNIA7zUFoP77YuI7hOc0A==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "MIT",
       "dependencies": {
         "chokidar": "^3.5.2",
         "debug": "^3.2.7",
@@ -3843,36 +6009,32 @@
     },
     "node_modules/nodemon/node_modules/debug": {
       "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ms": "^2.1.1"
       }
     },
     "node_modules/nodemon/node_modules/has-flag": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
     },
     "node_modules/nodemon/node_modules/semver": {
       "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
       "dev": true,
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver"
       }
     },
     "node_modules/nodemon/node_modules/supports-color": {
       "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "has-flag": "^3.0.0"
       },
@@ -3882,32 +6044,26 @@
     },
     "node_modules/nopt": {
       "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
-      "integrity": "sha512-NWmpvLSqUrgrAC9HCuxEvb+PSloHpqVu+FqcO4eeF2h5qYRhA7ev6KvelyQAKtegUbC6RypJnlEOhd8vloNKYg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "abbrev": "1"
       },
       "bin": {
         "nopt": "bin/nopt.js"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "devOptional": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/nunjucks": {
       "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/nunjucks/-/nunjucks-3.2.3.tgz",
-      "integrity": "sha512-psb6xjLj47+fE76JdZwskvwG4MYsQKXUtMsPh6U0YMvmyjRtKRFcxnlXGWglNybtNTNVmGdp94K62/+NjF5FDQ==",
+      "license": "BSD-2-Clause",
       "dependencies": {
         "a-sync-waterfall": "^1.0.0",
         "asap": "^2.0.3",
@@ -3939,16 +6095,14 @@
     },
     "node_modules/object-hash": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
-      "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==",
+      "license": "MIT",
       "engines": {
         "node": ">= 6"
       }
     },
     "node_modules/object-inspect": {
       "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
-      "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==",
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -3963,14 +6117,14 @@
       }
     },
     "node_modules/object.assign": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
-      "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.3.tgz",
+      "integrity": "sha512-ZFJnX3zltyjcYJL0RoCJuzb+11zWGyaDbjgxZbdV7rFEcHQuYxrZqhow67aA7xpes6LhojyFDaBKAFfogQrikA==",
       "dev": true,
       "dependencies": {
-        "call-bind": "^1.0.0",
-        "define-properties": "^1.1.3",
-        "has-symbols": "^1.0.1",
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "has-symbols": "^1.0.3",
         "object-keys": "^1.1.1"
       },
       "engines": {
@@ -4043,16 +6197,14 @@
     },
     "node_modules/oidc-token-hash": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/oidc-token-hash/-/oidc-token-hash-5.0.1.tgz",
-      "integrity": "sha512-EvoOtz6FIEBzE+9q253HsLCVRiK/0doEJ2HCvvqMQb3dHZrP3WlJKYtJ55CRTw4jmYomzH4wkPuCj/I3ZvpKxQ==",
+      "license": "MIT",
       "engines": {
         "node": "^10.13.0 || >=12.0.0"
       }
     },
     "node_modules/on-finished": {
       "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
-      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
       "dependencies": {
         "ee-first": "1.1.1"
       },
@@ -4062,25 +6214,44 @@
     },
     "node_modules/on-headers": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
-      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
     },
     "node_modules/once": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "wrappy": "1"
       }
     },
+    "node_modules/one-time": {
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "fn.name": "1.x.x"
+      }
+    },
+    "node_modules/open": {
+      "version": "8.4.0",
+      "license": "MIT",
+      "dependencies": {
+        "define-lazy-prop": "^2.0.0",
+        "is-docker": "^2.1.1",
+        "is-wsl": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/openid-client": {
-      "version": "5.1.7",
-      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-5.1.7.tgz",
-      "integrity": "sha512-VNtf/q+fv2Jiqi0ViLVmN3gGMSHF+YUGW6baKA/naoPKkKw4JdvghaP/kXQ/bzRRDWk6VmpCYDcR934UdDs8ug==",
+      "version": "5.1.8",
+      "license": "MIT",
       "dependencies": {
         "jose": "^4.1.4",
         "lru-cache": "^6.0.0",
@@ -4096,9 +6267,8 @@
     },
     "node_modules/optionator": {
       "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
-      "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "deep-is": "^0.1.3",
         "fast-levenshtein": "^2.0.6",
@@ -4113,9 +6283,8 @@
     },
     "node_modules/p-limit": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "yocto-queue": "^0.1.0"
       },
@@ -4128,9 +6297,8 @@
     },
     "node_modules/p-locate": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "p-limit": "^3.0.2"
       },
@@ -4152,9 +6320,8 @@
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
-      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "callsites": "^3.0.0"
       },
@@ -4164,35 +6331,31 @@
     },
     "node_modules/parseurl": {
       "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
-      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/path-key": {
       "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -4205,32 +6368,28 @@
     },
     "node_modules/path-to-regexp": {
       "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-      "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ=="
+      "license": "MIT"
     },
     "node_modules/path-type": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/pathval": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
-      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "*"
       }
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "devOptional": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8.6"
       },
@@ -4240,9 +6399,8 @@
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
-      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
       }
@@ -4275,6 +6433,32 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/promise-polyfill": {
+      "version": "1.1.6",
+      "license": "MIT"
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -4286,10 +6470,15 @@
         "react-is": "^16.13.1"
       }
     },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "dev": true
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
-      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
       "dependencies": {
         "forwarded": "0.2.0",
         "ipaddr.js": "1.9.1"
@@ -4300,23 +6489,20 @@
     },
     "node_modules/pstree.remy": {
       "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
-      "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/punycode": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/qs": {
       "version": "6.10.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz",
-      "integrity": "sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.0.4"
       },
@@ -4329,8 +6515,6 @@
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
       "funding": [
         {
           "type": "github",
@@ -4344,29 +6528,26 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
+      ],
+      "license": "MIT"
     },
     "node_modules/randombytes": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "safe-buffer": "^5.1.0"
       }
     },
     "node_modules/range-parser": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
-      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/raw-body": {
       "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
-      "integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
+      "license": "MIT",
       "dependencies": {
         "bytes": "3.1.2",
         "http-errors": "2.0.0",
@@ -4379,8 +6560,7 @@
     },
     "node_modules/rdf-canonize": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/rdf-canonize/-/rdf-canonize-3.0.0.tgz",
-      "integrity": "sha512-LXRkhab1QaPJnhUIt1gtXXKswQCZ9zpflsSZFczG7mCLAkMvVjdqCGk9VXCUss0aOUeEyV2jtFxGcdX8DSkj9w==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "setimmediate": "^1.0.5"
       },
@@ -4388,24 +6568,170 @@
         "node": ">=12"
       }
     },
-    "node_modules/rdf-js": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/rdf-js/-/rdf-js-4.0.2.tgz",
-      "integrity": "sha512-ApvlFa/WsQh8LpPK/6hctQwG06Z9ztQQGWVtrcrf9L6+sejHNXLPOqL+w7q3hF+iL0C4sv3AX1PUtGkLNzyZ0Q==",
+    "node_modules/rdf-data-factory": {
+      "version": "1.1.1",
+      "license": "MIT",
       "dependencies": {
         "@rdfjs/types": "*"
       }
     },
+    "node_modules/rdf-isomorphic": {
+      "version": "1.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "hash.js": "^1.1.7",
+        "rdf-string": "^1.6.0",
+        "rdf-terms": "^1.7.0"
+      }
+    },
+    "node_modules/rdf-js": {
+      "version": "4.0.2",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "*"
+      }
+    },
+    "node_modules/rdf-literal": {
+      "version": "1.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "rdf-data-factory": "^1.1.0"
+      }
+    },
+    "node_modules/rdf-object": {
+      "version": "1.13.1",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "jsonld-context-parser": "^2.0.2",
+        "rdf-data-factory": "^1.1.0",
+        "rdf-string": "^1.6.0",
+        "streamify-array": "^1.0.1"
+      }
+    },
+    "node_modules/rdf-parse": {
+      "version": "2.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/actor-http-fetch": "^2.0.1",
+        "@comunica/actor-http-proxy": "^2.0.1",
+        "@comunica/actor-rdf-parse-html": "^2.0.1",
+        "@comunica/actor-rdf-parse-html-microdata": "^2.0.1",
+        "@comunica/actor-rdf-parse-html-rdfa": "^2.0.1",
+        "@comunica/actor-rdf-parse-html-script": "^2.0.1",
+        "@comunica/actor-rdf-parse-jsonld": "^2.0.1",
+        "@comunica/actor-rdf-parse-n3": "^2.0.1",
+        "@comunica/actor-rdf-parse-rdfxml": "^2.0.1",
+        "@comunica/actor-rdf-parse-xml-rdfa": "^2.0.1",
+        "@comunica/bus-http": "^2.0.1",
+        "@comunica/bus-init": "^2.0.1",
+        "@comunica/bus-rdf-parse": "^2.0.1",
+        "@comunica/bus-rdf-parse-html": "^2.0.1",
+        "@comunica/config-query-sparql": "^2.0.1",
+        "@comunica/core": "^2.0.1",
+        "@comunica/mediator-combine-pipeline": "^2.0.1",
+        "@comunica/mediator-combine-union": "^2.0.1",
+        "@comunica/mediator-number": "^2.0.1",
+        "@comunica/mediator-race": "^2.0.1",
+        "@rdfjs/types": "*",
+        "stream-to-string": "^1.2.0"
+      }
+    },
+    "node_modules/rdf-quad": {
+      "version": "1.5.0",
+      "license": "MIT",
+      "dependencies": {
+        "rdf-data-factory": "^1.0.1",
+        "rdf-literal": "^1.2.0",
+        "rdf-string": "^1.5.0"
+      }
+    },
+    "node_modules/rdf-store-stream": {
+      "version": "1.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "n3": "^1.11.1"
+      }
+    },
+    "node_modules/rdf-string": {
+      "version": "1.6.1",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "rdf-data-factory": "^1.1.0"
+      }
+    },
+    "node_modules/rdf-string-ttl": {
+      "version": "1.2.0",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "rdf-data-factory": "^1.1.0"
+      }
+    },
+    "node_modules/rdf-terms": {
+      "version": "1.9.0",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "rdf-data-factory": "^1.1.0",
+        "rdf-string": "^1.6.0"
+      }
+    },
+    "node_modules/rdfa-streaming-parser": {
+      "version": "1.5.0",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "htmlparser2": "^6.0.0",
+        "rdf-data-factory": "^1.1.0",
+        "relative-to-absolute-iri": "^1.0.2"
+      }
+    },
+    "node_modules/rdfa-streaming-parser/node_modules/entities": {
+      "version": "2.2.0",
+      "license": "BSD-2-Clause",
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/rdfa-streaming-parser/node_modules/htmlparser2": {
+      "version": "6.1.0",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.0.1",
+        "domhandler": "^4.0.0",
+        "domutils": "^2.5.2",
+        "entities": "^2.0.0"
+      }
+    },
+    "node_modules/rdfxml-streaming-parser": {
+      "version": "1.5.0",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "rdf-data-factory": "^1.1.0",
+        "relative-to-absolute-iri": "^1.0.0",
+        "sax": "^1.2.4"
+      }
+    },
     "node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true
+      "version": "17.0.2",
+      "license": "MIT"
     },
     "node_modules/readable-stream": {
       "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -4415,11 +6741,28 @@
         "node": ">= 6"
       }
     },
+    "node_modules/readable-stream-node-to-web": {
+      "version": "1.0.1",
+      "license": "MIT"
+    },
+    "node_modules/readable-web-to-node-stream": {
+      "version": "3.0.2",
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
     "node_modules/readdirp": {
       "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
       "devOptional": true,
+      "license": "MIT",
       "dependencies": {
         "picomatch": "^2.2.1"
       },
@@ -4429,8 +6772,7 @@
     },
     "node_modules/regenerator-runtime": {
       "version": "0.13.9",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
+      "license": "MIT"
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.4.3",
@@ -4451,9 +6793,8 @@
     },
     "node_modules/regexpp": {
       "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
-      "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       },
@@ -4461,11 +6802,13 @@
         "url": "https://github.com/sponsors/mysticatea"
       }
     },
+    "node_modules/relative-to-absolute-iri": {
+      "version": "1.0.6",
+      "license": "MIT"
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4489,18 +6832,16 @@
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
     },
     "node_modules/reusify": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
-      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
@@ -4508,9 +6849,8 @@
     },
     "node_modules/rimraf": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -4521,30 +6861,8 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/rimraf/node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "dev": true,
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
-      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
       "dev": true,
       "funding": [
         {
@@ -4560,14 +6878,13 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
       "funding": [
         {
           "type": "github",
@@ -4581,17 +6898,24 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.3.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+      "license": "MIT"
     },
     "node_modules/sass": {
-      "version": "1.54.3",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.54.3.tgz",
-      "integrity": "sha512-fLodey5Qd41Pxp/Tk7Al97sViYwF/TazRc5t6E65O7JOk4XF8pzwIW7CvCxYVOfJFFI/1x5+elDyBIixrp+zrw==",
+      "version": "1.54.4",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.54.4.tgz",
+      "integrity": "sha512-3tmF16yvnBwtlPrNBHw/H907j8MlOX8aTBnlNX1yrKx24RKcJGPyLhFUwkoKBKesR3unP93/2z14Ll8NicwQUA==",
       "dev": true,
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0",
@@ -4605,19 +6929,45 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/sax": {
+      "version": "1.2.4",
+      "license": "ISC"
+    },
+    "node_modules/sax-stream": {
+      "version": "1.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "~2",
+        "sax": "~1"
+      }
+    },
+    "node_modules/sax-stream/node_modules/debug": {
+      "version": "2.6.9",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/sax-stream/node_modules/ms": {
+      "version": "2.0.0",
+      "license": "MIT"
+    },
     "node_modules/semver": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
-      "integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==",
-      "dev": true,
+      "version": "7.3.7",
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
       "bin": {
         "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/send": {
       "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.18.0.tgz",
-      "integrity": "sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==",
+      "license": "MIT",
       "dependencies": {
         "debug": "2.6.9",
         "depd": "2.0.0",
@@ -4639,30 +6989,29 @@
     },
     "node_modules/send/node_modules/debug": {
       "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
       }
     },
     "node_modules/send/node_modules/debug/node_modules/ms": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+      "license": "MIT"
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "license": "MIT"
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
-      "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
-      "dev": true,
+      "version": "4.0.0",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "randombytes": "^2.1.0"
       }
     },
     "node_modules/serve-static": {
       "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.15.0.tgz",
-      "integrity": "sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g==",
+      "license": "MIT",
       "dependencies": {
         "encodeurl": "~1.0.2",
         "escape-html": "~1.0.3",
@@ -4675,19 +7024,16 @@
     },
     "node_modules/setimmediate": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
+      "license": "MIT"
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
-      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
+      "license": "ISC"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
       },
@@ -4697,17 +7043,15 @@
     },
     "node_modules/shebang-regex": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/side-channel": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
-      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+      "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.0",
         "get-intrinsic": "^1.0.2",
@@ -4717,11 +7061,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.2",
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
+      }
+    },
     "node_modules/simple-update-notifier": {
       "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-1.0.7.tgz",
-      "integrity": "sha512-BBKgR84BJQJm6WjWFMHgLVuo61FBDSj1z/xSFUIozqO6wO7ii0JxCqlIud7Enr/+LhlbNI0whErq96P2qHNWew==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "semver": "~7.0.0"
       },
@@ -4729,11 +7079,18 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/simple-update-notifier/node_modules/semver": {
+      "version": "7.0.0",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/sinon": {
       "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-14.0.0.tgz",
-      "integrity": "sha512-ugA6BFmE+WrJdh0owRZHToLd32Uw3Lxq6E6LtNRU+xTVBefx632h03Q7apXWRsRdZAJ41LB8aUfn2+O4jsDNMw==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "@sinonjs/commons": "^1.8.3",
         "@sinonjs/fake-timers": "^9.1.2",
@@ -4749,62 +7106,174 @@
     },
     "node_modules/sinon-chai": {
       "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-3.7.0.tgz",
-      "integrity": "sha512-mf5NURdUaSdnatJx3uhoBOrY9dtL19fiOtAdT1Azxg3+lNJFiuN0uzaU3xX1LeAfL17kHQhTAJgpsfhbMJMY2g==",
       "dev": true,
+      "license": "(BSD-2-Clause OR WTFPL)",
       "peerDependencies": {
         "chai": "^4.0.0",
         "sinon": ">=4.0.0"
       }
     },
-    "node_modules/sinon/node_modules/diff": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-5.1.0.tgz",
-      "integrity": "sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.3.1"
-      }
-    },
     "node_modules/slash": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
+    "node_modules/solid-node-interactive-auth": {
+      "version": "1.0.2",
+      "license": "MIT",
+      "dependencies": {
+        "open": "^8.2.1"
+      },
+      "bin": {
+        "solid-node-interactive-auth": "bin/solid-node-interactive-auth"
+      },
+      "peerDependencies": {
+        "@inrupt/solid-client-authn-node": ">=1.11.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
-      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
       }
     },
+    "node_modules/spark-md5": {
+      "version": "3.0.2",
+      "license": "(WTFPL OR MIT)"
+    },
+    "node_modules/sparqlalgebrajs": {
+      "version": "4.0.3",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "@types/sparqljs": "^3.1.3",
+        "fast-deep-equal": "^3.1.3",
+        "minimist": "^1.2.6",
+        "rdf-data-factory": "^1.1.0",
+        "rdf-isomorphic": "^1.3.0",
+        "rdf-string": "^1.6.0",
+        "sparqljs": "^3.5.2"
+      },
+      "bin": {
+        "sparqlalgebrajs": "bin/sparqlalgebrajs.js"
+      }
+    },
+    "node_modules/sparqlee": {
+      "version": "2.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bindings-factory": "^2.0.1",
+        "@rdfjs/types": "*",
+        "@types/lru-cache": "^5.1.1",
+        "@types/spark-md5": "^3.0.2",
+        "@types/uuid": "^8.0.0",
+        "bignumber.js": "^9.0.1",
+        "hash.js": "^1.1.7",
+        "lru-cache": "^6.0.0",
+        "rdf-data-factory": "^1.1.0",
+        "rdf-string": "^1.6.0",
+        "relative-to-absolute-iri": "^1.0.6",
+        "spark-md5": "^3.0.1",
+        "sparqlalgebrajs": "^4.0.0",
+        "uuid": "^8.0.0"
+      },
+      "bin": {
+        "sparqlee": "dist/bin/sparqlee.js"
+      }
+    },
+    "node_modules/sparqljs": {
+      "version": "3.5.2",
+      "license": "MIT",
+      "dependencies": {
+        "rdf-data-factory": "^1.0.4"
+      },
+      "bin": {
+        "sparqljs": "bin/sparql-to-json"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/sparqljson-parse": {
+      "version": "1.7.0",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "@types/node": "^13.1.0",
+        "JSONStream": "^1.3.3",
+        "rdf-data-factory": "^1.1.0"
+      }
+    },
+    "node_modules/sparqljson-parse/node_modules/@types/node": {
+      "version": "13.13.52",
+      "license": "MIT"
+    },
+    "node_modules/sparqljson-to-tree": {
+      "version": "2.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "rdf-literal": "^1.2.0",
+        "sparqljson-parse": "^1.6.0"
+      }
+    },
+    "node_modules/sparqlxml-parse": {
+      "version": "1.5.0",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "@types/node": "^13.1.0",
+        "rdf-data-factory": "^1.1.0",
+        "sax-stream": "^1.2.3"
+      }
+    },
+    "node_modules/sparqlxml-parse/node_modules/@types/node": {
+      "version": "13.13.52",
+      "license": "MIT"
+    },
+    "node_modules/stack-trace": {
+      "version": "0.0.10",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
     },
+    "node_modules/stream-to-string": {
+      "version": "1.2.0",
+      "license": "MIT",
+      "dependencies": {
+        "promise-polyfill": "^1.1.6"
+      }
+    },
+    "node_modules/streamify-array": {
+      "version": "1.0.1",
+      "license": "MIT"
+    },
+    "node_modules/streamify-string": {
+      "version": "1.0.1",
+      "license": "MIT"
+    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/string-width": {
       "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -4863,9 +7332,7 @@
     },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -4884,9 +7351,8 @@
     },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       },
@@ -4896,9 +7362,7 @@
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -4918,17 +7382,23 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/text-hex": {
+      "version": "1.0.0",
+      "license": "MIT"
+    },
     "node_modules/text-table": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/through": {
+      "version": "2.3.8",
+      "license": "MIT"
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
       "devOptional": true,
+      "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
       },
@@ -4938,17 +7408,15 @@
     },
     "node_modules/toidentifier": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
-      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.6"
       }
     },
     "node_modules/touch": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/touch/-/touch-3.1.0.tgz",
-      "integrity": "sha512-WBx8Uy5TLtOSRtIq+M03/sKDrXCLHxwDcquSP2c43Le03/9serjQBIztjRz6FkJez9D/hleyAXTBGLwwZUw9lA==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "nopt": "~1.0.10"
       },
@@ -4958,14 +7426,16 @@
     },
     "node_modules/tr46": {
       "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+      "license": "MIT"
+    },
+    "node_modules/triple-beam": {
+      "version": "1.3.0",
+      "license": "MIT"
     },
     "node_modules/ts-node": {
       "version": "10.9.1",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
-      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -5004,11 +7474,21 @@
         }
       }
     },
+    "node_modules/ts-node/node_modules/acorn": {
+      "version": "8.8.0",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/ts-node/node_modules/diff": {
       "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
       }
@@ -5027,23 +7507,20 @@
     },
     "node_modules/tslib": {
       "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true
+      "dev": true,
+      "license": "0BSD"
     },
     "node_modules/tsscmp": {
       "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
-      "integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.6.x"
       }
     },
     "node_modules/tsutils": {
       "version": "3.21.0",
-      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
-      "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "tslib": "^1.8.1"
       },
@@ -5056,9 +7533,8 @@
     },
     "node_modules/type-check": {
       "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
-      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "prelude-ls": "^1.2.1"
       },
@@ -5068,18 +7544,16 @@
     },
     "node_modules/type-detect": {
       "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
     },
     "node_modules/type-fest": {
       "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
       "dev": true,
+      "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=10"
       },
@@ -5089,8 +7563,7 @@
     },
     "node_modules/type-is": {
       "version": "1.6.18",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
-      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
       "dependencies": {
         "media-typer": "0.3.0",
         "mime-types": "~2.1.24"
@@ -5101,9 +7574,8 @@
     },
     "node_modules/typescript": {
       "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5129,77 +7601,89 @@
     },
     "node_modules/undefsafe": {
       "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
-      "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/unpipe": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
-      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/uritemplate": {
+      "version": "0.3.4"
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+      "license": "MIT"
     },
     "node_modules/utils-merge": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
       }
     },
     "node_modules/uuid": {
       "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
-      "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
-      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vary": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
-      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
     },
+    "node_modules/web-streams-node": {
+      "version": "0.4.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "is-stream": "^1.1.0",
+        "readable-stream-node-to-web": "^1.0.1",
+        "web-streams-ponyfill": "^1.4.1"
+      }
+    },
+    "node_modules/web-streams-node/node_modules/is-stream": {
+      "version": "1.1.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/web-streams-ponyfill": {
+      "version": "1.4.2",
+      "license": "MIT"
+    },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+      "license": "BSD-2-Clause"
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -5207,9 +7691,8 @@
     },
     "node_modules/which": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -5236,26 +7719,53 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/winston": {
+      "version": "3.8.1",
+      "license": "MIT",
+      "dependencies": {
+        "@dabh/diagnostics": "^2.0.2",
+        "async": "^3.2.3",
+        "is-stream": "^2.0.0",
+        "logform": "^2.4.0",
+        "one-time": "^1.0.0",
+        "readable-stream": "^3.4.0",
+        "safe-stable-stringify": "^2.3.1",
+        "stack-trace": "0.0.x",
+        "triple-beam": "^1.3.0",
+        "winston-transport": "^4.5.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/winston-transport": {
+      "version": "4.5.0",
+      "license": "MIT",
+      "dependencies": {
+        "logform": "^2.3.2",
+        "readable-stream": "^3.6.0",
+        "triple-beam": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 6.4.0"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/workerpool": {
       "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.1.tgz",
-      "integrity": "sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==",
-      "dev": true
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -5270,56 +7780,52 @@
     },
     "node_modules/wrappy": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/xml": {
+      "version": "1.0.1",
+      "license": "MIT"
     },
     "node_modules/y18n": {
       "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-      "dev": true,
+      "license": "ISC",
       "engines": {
         "node": ">=10"
       }
     },
     "node_modules/yallist": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+      "license": "ISC"
     },
     "node_modules/yargs": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
-      "dev": true,
+      "version": "17.5.1",
+      "license": "MIT",
       "dependencies": {
         "cliui": "^7.0.2",
         "escalade": "^3.1.1",
         "get-caller-file": "^2.0.5",
         "require-directory": "^2.1.1",
-        "string-width": "^4.2.0",
+        "string-width": "^4.2.3",
         "y18n": "^5.0.5",
-        "yargs-parser": "^20.2.2"
+        "yargs-parser": "^21.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       }
     },
     "node_modules/yargs-parser": {
       "version": "20.2.4",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
-      "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
       "dev": true,
+      "license": "ISC",
       "engines": {
         "node": ">=10"
       }
     },
     "node_modules/yargs-unparser": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
-      "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "camelcase": "^6.0.0",
         "decamelize": "^4.0.0",
@@ -5331,28 +7837,24 @@
       }
     },
     "node_modules/yargs/node_modules/yargs-parser": {
-      "version": "20.2.9",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
-      "dev": true,
+      "version": "21.1.0",
+      "license": "ISC",
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       }
     },
     "node_modules/yn": {
       "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
-      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -5364,8 +7866,6 @@
   "dependencies": {
     "@babel/runtime": {
       "version": "7.18.9",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.18.9.tgz",
-      "integrity": "sha512-lkqXDcvlFT5rvEjiu6+QYO+1GXrEHRo2LOtS7E4GtX5ESIZOgepqsZBVIj6Pv+a6zqsya9VCgiK1KAK4BvJDAw==",
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
@@ -5380,19 +7880,1679 @@
         "regenerator-runtime": "^0.13.4"
       }
     },
+    "@colors/colors": {
+      "version": "1.5.0"
+    },
+    "@comunica/actor-abstract-mediatyped": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0"
+      }
+    },
+    "@comunica/actor-abstract-parse": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/core": "^2.3.0"
+      }
+    },
+    "@comunica/actor-abstract-path": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/bindings-factory": "^2.2.0",
+        "@comunica/bus-query-operation": "^2.3.0",
+        "@comunica/context-entries": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.4.2",
+        "rdf-data-factory": "^1.0.3",
+        "rdf-string": "^1.5.0",
+        "sparqlalgebrajs": "^4.0.0"
+      }
+    },
+    "@comunica/actor-context-preprocess-source-to-destination": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/bus-context-preprocess": "^2.3.0",
+        "@comunica/context-entries": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0"
+      }
+    },
+    "@comunica/actor-dereference-fallback": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/bus-dereference": "^2.3.0",
+        "@comunica/core": "^2.3.0"
+      }
+    },
+    "@comunica/actor-dereference-http": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/bus-dereference": "^2.3.0",
+        "@comunica/bus-http": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "cross-fetch": "^3.0.5",
+        "relative-to-absolute-iri": "^1.0.5",
+        "stream-to-string": "^1.2.0"
+      }
+    },
+    "@comunica/actor-dereference-rdf-parse": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/bus-dereference": "^2.3.0",
+        "@comunica/bus-dereference-rdf": "^2.3.0",
+        "@comunica/bus-rdf-parse": "^2.3.0"
+      }
+    },
+    "@comunica/actor-hash-bindings-sha1": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/bus-hash-bindings": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "canonicalize": "^1.0.8",
+        "hash.js": "^1.1.7",
+        "rdf-string": "^1.5.0"
+      }
+    },
+    "@comunica/actor-http-fetch": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/bus-http": "^2.3.0",
+        "@comunica/context-entries": "^2.3.0",
+        "@comunica/mediatortype-time": "^2.3.0",
+        "abort-controller": "^3.0.0",
+        "cross-fetch": "^3.0.5"
+      }
+    },
+    "@comunica/actor-http-inrupt-solid-client-authn": {
+      "version": "2.2.0",
+      "requires": {
+        "@comunica/bus-http": "^2.0.1",
+        "@comunica/context-entries": "^2.0.1",
+        "@comunica/core": "^2.0.1",
+        "@rubensworks/solid-client-authn-isomorphic": "^2.0.0"
+      }
+    },
+    "@comunica/actor-http-proxy": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/bus-http": "^2.3.0",
+        "@comunica/context-entries": "^2.3.0",
+        "@comunica/mediatortype-time": "^2.3.0",
+        "@comunica/types": "^2.3.0"
+      }
+    },
+    "@comunica/actor-init-query": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/actor-http-proxy": "^2.3.0",
+        "@comunica/bus-context-preprocess": "^2.3.0",
+        "@comunica/bus-http-invalidate": "^2.3.0",
+        "@comunica/bus-init": "^2.3.0",
+        "@comunica/bus-optimize-query-operation": "^2.3.0",
+        "@comunica/bus-query-operation": "^2.3.0",
+        "@comunica/bus-query-parse": "^2.3.0",
+        "@comunica/bus-query-result-serialize": "^2.3.0",
+        "@comunica/context-entries": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/logger-pretty": "^2.3.0",
+        "@comunica/runner": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "@rdfjs/types": "*",
+        "@types/yargs": "^17.0.2",
+        "asynciterator": "^3.4.2",
+        "negotiate": "^1.0.1",
+        "rdf-quad": "^1.4.0",
+        "rdf-string": "^1.5.0",
+        "sparqlalgebrajs": "^4.0.0",
+        "streamify-string": "^1.0.1",
+        "yargs": "^17.1.1"
+      }
+    },
+    "@comunica/actor-optimize-query-operation-bgp-to-join": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/bus-optimize-query-operation": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "sparqlalgebrajs": "^4.0.0"
+      }
+    },
+    "@comunica/actor-optimize-query-operation-join-bgp": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/bus-optimize-query-operation": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "sparqlalgebrajs": "^4.0.0"
+      }
+    },
+    "@comunica/actor-optimize-query-operation-join-connected": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/bus-optimize-query-operation": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "sparqlalgebrajs": "^4.0.0"
+      }
+    },
+    "@comunica/actor-query-operation-ask": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/bus-query-operation": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "sparqlalgebrajs": "^4.0.0"
+      }
+    },
+    "@comunica/actor-query-operation-bgp-join": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/bus-query-operation": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "sparqlalgebrajs": "^4.0.0"
+      }
+    },
+    "@comunica/actor-query-operation-construct": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/bus-query-operation": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.4.2",
+        "rdf-data-factory": "^1.0.3",
+        "rdf-terms": "^1.6.2",
+        "sparqlalgebrajs": "^4.0.0"
+      }
+    },
+    "@comunica/actor-query-operation-describe-subject": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/actor-query-operation-union": "^2.3.0",
+        "@comunica/bus-query-operation": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "asynciterator": "^3.4.2",
+        "rdf-data-factory": "^1.0.3",
+        "sparqlalgebrajs": "^4.0.0"
+      }
+    },
+    "@comunica/actor-query-operation-distinct-hash": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/bus-hash-bindings": "^2.3.0",
+        "@comunica/bus-query-operation": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "sparqlalgebrajs": "^4.0.0"
+      }
+    },
+    "@comunica/actor-query-operation-extend": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/bindings-factory": "^2.2.0",
+        "@comunica/bus-query-operation": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "sparqlalgebrajs": "^4.0.0",
+        "sparqlee": "^2.1.0"
+      }
+    },
+    "@comunica/actor-query-operation-filter-sparqlee": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/bindings-factory": "^2.2.0",
+        "@comunica/bus-query-operation": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "sparqlalgebrajs": "^4.0.0",
+        "sparqlee": "^2.1.0"
+      }
+    },
+    "@comunica/actor-query-operation-from-quad": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/bus-query-operation": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "@rdfjs/types": "*",
+        "sparqlalgebrajs": "^4.0.0"
+      }
+    },
+    "@comunica/actor-query-operation-group": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/bindings-factory": "^2.2.0",
+        "@comunica/bus-hash-bindings": "^2.3.0",
+        "@comunica/bus-query-operation": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.4.2",
+        "rdf-data-factory": "^1.1.0",
+        "sparqlalgebrajs": "^4.0.0",
+        "sparqlee": "^2.1.0"
+      }
+    },
+    "@comunica/actor-query-operation-join": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/bus-query-operation": "^2.3.0",
+        "@comunica/bus-rdf-join": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "sparqlalgebrajs": "^4.0.0"
+      }
+    },
+    "@comunica/actor-query-operation-leftjoin": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/bus-query-operation": "^2.3.0",
+        "@comunica/bus-rdf-join": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "sparqlalgebrajs": "^4.0.0",
+        "sparqlee": "^2.1.0"
+      }
+    },
+    "@comunica/actor-query-operation-minus": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/bus-query-operation": "^2.3.0",
+        "@comunica/bus-rdf-join": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "sparqlalgebrajs": "^4.0.0"
+      }
+    },
+    "@comunica/actor-query-operation-nop": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/bindings-factory": "^2.2.0",
+        "@comunica/bus-query-operation": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "asynciterator": "^3.4.2",
+        "sparqlalgebrajs": "^4.0.0"
+      }
+    },
+    "@comunica/actor-query-operation-orderby-sparqlee": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/bus-query-operation": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "asynciterator": "^3.4.2",
+        "sparqlalgebrajs": "^4.0.0",
+        "sparqlee": "^2.1.0"
+      }
+    },
+    "@comunica/actor-query-operation-path-alt": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/actor-abstract-path": "^2.3.0",
+        "@comunica/actor-query-operation-union": "^2.3.0",
+        "@comunica/bus-query-operation": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "asynciterator": "^3.4.2",
+        "sparqlalgebrajs": "^4.0.0"
+      }
+    },
+    "@comunica/actor-query-operation-path-inv": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/actor-abstract-path": "^2.3.0",
+        "@comunica/bus-query-operation": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "sparqlalgebrajs": "^4.0.0"
+      }
+    },
+    "@comunica/actor-query-operation-path-link": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/actor-abstract-path": "^2.3.0",
+        "@comunica/bus-query-operation": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "sparqlalgebrajs": "^4.0.0"
+      }
+    },
+    "@comunica/actor-query-operation-path-nps": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/actor-abstract-path": "^2.3.0",
+        "@comunica/bus-query-operation": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "sparqlalgebrajs": "^4.0.0"
+      }
+    },
+    "@comunica/actor-query-operation-path-one-or-more": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/actor-abstract-path": "^2.3.0",
+        "@comunica/bindings-factory": "^2.2.0",
+        "@comunica/bus-query-operation": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "asynciterator": "^3.4.2",
+        "sparqlalgebrajs": "^4.0.0"
+      }
+    },
+    "@comunica/actor-query-operation-path-seq": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/actor-abstract-path": "^2.3.0",
+        "@comunica/bus-query-operation": "^2.3.0",
+        "@comunica/bus-rdf-join": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "sparqlalgebrajs": "^4.0.0"
+      }
+    },
+    "@comunica/actor-query-operation-path-zero-or-more": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/actor-abstract-path": "^2.3.0",
+        "@comunica/bindings-factory": "^2.2.0",
+        "@comunica/bus-query-operation": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "asynciterator": "^3.4.2",
+        "rdf-string": "^1.5.0",
+        "sparqlalgebrajs": "^4.0.0"
+      }
+    },
+    "@comunica/actor-query-operation-path-zero-or-one": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/actor-abstract-path": "^2.3.0",
+        "@comunica/bindings-factory": "^2.2.0",
+        "@comunica/bus-query-operation": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "asynciterator": "^3.4.2",
+        "sparqlalgebrajs": "^4.0.0"
+      }
+    },
+    "@comunica/actor-query-operation-project": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/bus-query-operation": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/data-factory": "^2.0.1",
+        "@comunica/types": "^2.3.0",
+        "@rdfjs/types": "*",
+        "rdf-data-factory": "^1.0.3",
+        "sparqlalgebrajs": "^4.0.0"
+      }
+    },
+    "@comunica/actor-query-operation-quadpattern": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/bindings-factory": "^2.2.0",
+        "@comunica/bus-query-operation": "^2.3.0",
+        "@comunica/bus-rdf-resolve-quad-pattern": "^2.3.0",
+        "@comunica/context-entries": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.4.2",
+        "rdf-data-factory": "^1.1.0",
+        "rdf-terms": "^1.6.2",
+        "sparqlalgebrajs": "^4.0.0"
+      }
+    },
+    "@comunica/actor-query-operation-reduced-hash": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/bus-hash-bindings": "^2.3.0",
+        "@comunica/bus-query-operation": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "@types/lru-cache": "^5.1.0",
+        "lru-cache": "^6.0.0",
+        "sparqlalgebrajs": "^4.0.0"
+      }
+    },
+    "@comunica/actor-query-operation-service": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/bindings-factory": "^2.2.0",
+        "@comunica/bus-query-operation": "^2.3.0",
+        "@comunica/context-entries": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "asynciterator": "^3.4.2",
+        "sparqlalgebrajs": "^4.0.0"
+      }
+    },
+    "@comunica/actor-query-operation-slice": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/bus-query-operation": "^2.3.0",
+        "@comunica/context-entries": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "sparqlalgebrajs": "^4.0.0"
+      }
+    },
+    "@comunica/actor-query-operation-sparql-endpoint": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/bindings-factory": "^2.2.0",
+        "@comunica/bus-http": "^2.3.0",
+        "@comunica/bus-query-operation": "^2.3.0",
+        "@comunica/bus-rdf-resolve-quad-pattern": "^2.3.0",
+        "@comunica/bus-rdf-update-quads": "^2.3.0",
+        "@comunica/context-entries": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/mediatortype-httprequests": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.4.2",
+        "fetch-sparql-endpoint": "^2.3.2",
+        "rdf-data-factory": "^1.1.0",
+        "sparqlalgebrajs": "^4.0.0"
+      }
+    },
+    "@comunica/actor-query-operation-union": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/bus-query-operation": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.4.2",
+        "rdf-terms": "^1.7.1",
+        "sparqlalgebrajs": "^4.0.0"
+      }
+    },
+    "@comunica/actor-query-operation-update-add-rewrite": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/bus-query-operation": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "rdf-data-factory": "^1.0.4",
+        "sparqlalgebrajs": "^4.0.0"
+      }
+    },
+    "@comunica/actor-query-operation-update-clear": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/bus-query-operation": "^2.3.0",
+        "@comunica/bus-rdf-update-quads": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "@rdfjs/types": "*",
+        "rdf-data-factory": "^1.0.4",
+        "sparqlalgebrajs": "^4.0.2"
+      }
+    },
+    "@comunica/actor-query-operation-update-compositeupdate": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/bus-query-operation": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "sparqlalgebrajs": "^4.0.2"
+      }
+    },
+    "@comunica/actor-query-operation-update-copy-rewrite": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/bus-query-operation": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "sparqlalgebrajs": "^4.0.0"
+      }
+    },
+    "@comunica/actor-query-operation-update-create": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/bus-query-operation": "^2.3.0",
+        "@comunica/bus-rdf-update-quads": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "sparqlalgebrajs": "^4.0.2"
+      }
+    },
+    "@comunica/actor-query-operation-update-deleteinsert": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/actor-query-operation-construct": "^2.3.0",
+        "@comunica/bindings-factory": "^2.2.0",
+        "@comunica/bus-query-operation": "^2.3.0",
+        "@comunica/bus-rdf-update-quads": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.4.2",
+        "sparqlalgebrajs": "^4.0.2"
+      }
+    },
+    "@comunica/actor-query-operation-update-drop": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/bus-query-operation": "^2.3.0",
+        "@comunica/bus-rdf-update-quads": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "@rdfjs/types": "*",
+        "rdf-data-factory": "^1.0.4",
+        "sparqlalgebrajs": "^4.0.2"
+      }
+    },
+    "@comunica/actor-query-operation-update-load": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/bus-query-operation": "^2.3.0",
+        "@comunica/bus-rdf-update-quads": "^2.3.0",
+        "@comunica/context-entries": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "rdf-data-factory": "^1.0.4",
+        "sparqlalgebrajs": "^4.0.0"
+      }
+    },
+    "@comunica/actor-query-operation-update-move-rewrite": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/bus-query-operation": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "sparqlalgebrajs": "^4.0.0"
+      }
+    },
+    "@comunica/actor-query-operation-values": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/bindings-factory": "^2.2.0",
+        "@comunica/bus-query-operation": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "asynciterator": "^3.4.2",
+        "rdf-data-factory": "^1.1.0",
+        "sparqlalgebrajs": "^4.0.0"
+      }
+    },
+    "@comunica/actor-query-parse-graphql": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/bus-query-parse": "^2.3.0",
+        "@comunica/context-entries": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "graphql-to-sparql": "^3.0.0"
+      }
+    },
+    "@comunica/actor-query-parse-sparql": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/bus-query-parse": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@types/sparqljs": "^3.0.0",
+        "sparqlalgebrajs": "^4.0.0",
+        "sparqljs": "^3.4.1"
+      }
+    },
+    "@comunica/actor-query-result-serialize-json": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/bus-query-result-serialize": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "rdf-string": "^1.5.0"
+      }
+    },
+    "@comunica/actor-query-result-serialize-rdf": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/bus-query-result-serialize": "^2.3.0",
+        "@comunica/bus-rdf-serialize": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0"
+      }
+    },
+    "@comunica/actor-query-result-serialize-simple": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/bus-query-result-serialize": "^2.3.0",
+        "@comunica/types": "^2.3.0"
+      }
+    },
+    "@comunica/actor-query-result-serialize-sparql-csv": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/bus-query-result-serialize": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "@rdfjs/types": "*"
+      }
+    },
+    "@comunica/actor-query-result-serialize-sparql-json": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/bus-query-result-serialize": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "@rdfjs/types": "*"
+      }
+    },
+    "@comunica/actor-query-result-serialize-sparql-tsv": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/bus-query-result-serialize": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "@rdfjs/types": "*",
+        "rdf-string-ttl": "^1.1.0"
+      }
+    },
+    "@comunica/actor-query-result-serialize-sparql-xml": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/bus-query-result-serialize": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "@rdfjs/types": "*",
+        "xml": "^1.0.1"
+      }
+    },
+    "@comunica/actor-query-result-serialize-stats": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/bus-http": "^2.3.0",
+        "@comunica/bus-query-result-serialize": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0"
+      }
+    },
+    "@comunica/actor-query-result-serialize-table": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/bus-query-result-serialize": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "@rdfjs/types": "*",
+        "rdf-data-factory": "^1.1.0",
+        "rdf-terms": "^1.6.2"
+      }
+    },
+    "@comunica/actor-query-result-serialize-tree": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/bus-query-result-serialize": "^2.3.0",
+        "@comunica/context-entries": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "sparqljson-to-tree": "^2.0.0"
+      }
+    },
+    "@comunica/actor-rdf-join-entries-sort-cardinality": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/bus-rdf-join-entries-sort": "^2.3.0",
+        "@comunica/core": "^2.3.0"
+      }
+    },
+    "@comunica/actor-rdf-join-inner-hash": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/bus-rdf-join": "^2.3.0",
+        "@comunica/mediatortype-join-coefficients": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "asyncjoin": "^1.0.5"
+      }
+    },
+    "@comunica/actor-rdf-join-inner-multi-bind": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/bus-query-operation": "^2.3.0",
+        "@comunica/bus-rdf-join": "^2.3.0",
+        "@comunica/bus-rdf-join-entries-sort": "^2.3.0",
+        "@comunica/context-entries": "^2.3.0",
+        "@comunica/mediatortype-join-coefficients": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "asynciterator": "^3.4.2",
+        "sparqlalgebrajs": "^4.0.0"
+      }
+    },
+    "@comunica/actor-rdf-join-inner-multi-empty": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/bus-rdf-join": "^2.3.0",
+        "@comunica/mediatortype-join-coefficients": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "asynciterator": "^3.4.2"
+      }
+    },
+    "@comunica/actor-rdf-join-inner-multi-smallest": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/bus-query-operation": "^2.3.0",
+        "@comunica/bus-rdf-join": "^2.3.0",
+        "@comunica/bus-rdf-join-entries-sort": "^2.3.0",
+        "@comunica/mediatortype-join-coefficients": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "sparqlalgebrajs": "^4.0.0"
+      }
+    },
+    "@comunica/actor-rdf-join-inner-nestedloop": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/bus-rdf-join": "^2.3.0",
+        "@comunica/mediatortype-join-coefficients": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "asyncjoin": "^1.0.5"
+      }
+    },
+    "@comunica/actor-rdf-join-inner-none": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/bindings-factory": "^2.2.0",
+        "@comunica/bus-rdf-join": "^2.3.0",
+        "@comunica/mediatortype-join-coefficients": "^2.3.0",
+        "asynciterator": "^3.4.2"
+      }
+    },
+    "@comunica/actor-rdf-join-inner-single": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/bus-rdf-join": "^2.3.0",
+        "@comunica/mediatortype-join-coefficients": "^2.3.0"
+      }
+    },
+    "@comunica/actor-rdf-join-inner-symmetrichash": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/bus-rdf-join": "^2.3.0",
+        "@comunica/mediatortype-join-coefficients": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "asyncjoin": "^1.0.5"
+      }
+    },
+    "@comunica/actor-rdf-join-minus-hash": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/bus-rdf-join": "^2.3.0",
+        "@comunica/mediatortype-join-coefficients": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.4.2"
+      }
+    },
+    "@comunica/actor-rdf-join-minus-hash-undef": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/bus-rdf-join": "^2.3.0",
+        "@comunica/mediatortype-join-coefficients": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.4.2",
+        "rdf-string": "^1.5.0"
+      }
+    },
+    "@comunica/actor-rdf-join-optional-bind": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/actor-rdf-join-inner-multi-bind": "^2.3.0",
+        "@comunica/bus-query-operation": "^2.3.0",
+        "@comunica/bus-rdf-join": "^2.3.0",
+        "@comunica/context-entries": "^2.3.0",
+        "@comunica/mediatortype-join-coefficients": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "sparqlalgebrajs": "^4.0.0"
+      }
+    },
+    "@comunica/actor-rdf-join-optional-nestedloop": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/bus-rdf-join": "^2.3.0",
+        "@comunica/mediatortype-join-coefficients": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "asyncjoin": "^1.0.5"
+      }
+    },
+    "@comunica/actor-rdf-join-selectivity-variable-counting": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/bus-rdf-join-selectivity": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/mediatortype-accuracy": "^2.3.0",
+        "sparqlalgebrajs": "^4.0.0"
+      }
+    },
+    "@comunica/actor-rdf-metadata-all": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/bus-rdf-metadata": "^2.3.0",
+        "@comunica/core": "^2.3.0"
+      }
+    },
+    "@comunica/actor-rdf-metadata-extract-allow-http-methods": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/bus-rdf-metadata-extract": "^2.3.0",
+        "@comunica/core": "^2.3.0"
+      }
+    },
+    "@comunica/actor-rdf-metadata-extract-hydra-controls": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/bus-rdf-metadata-extract": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@rdfjs/types": "*",
+        "@types/uritemplate": "^0.3.4",
+        "uritemplate": "0.3.4"
+      }
+    },
+    "@comunica/actor-rdf-metadata-extract-hydra-count": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/bus-rdf-metadata-extract": "^2.3.0",
+        "@comunica/core": "^2.3.0"
+      }
+    },
+    "@comunica/actor-rdf-metadata-extract-hydra-pagesize": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/bus-rdf-metadata-extract": "^2.3.0",
+        "@comunica/core": "^2.3.0"
+      }
+    },
+    "@comunica/actor-rdf-metadata-extract-patch-sparql-update": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/bus-rdf-metadata-extract": "^2.3.0",
+        "@comunica/core": "^2.3.0"
+      }
+    },
+    "@comunica/actor-rdf-metadata-extract-put-accepted": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/bus-rdf-metadata-extract": "^2.3.0",
+        "@comunica/core": "^2.3.0"
+      }
+    },
+    "@comunica/actor-rdf-metadata-extract-request-time": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/bus-rdf-metadata-extract": "^2.3.0",
+        "@comunica/core": "^2.3.0"
+      }
+    },
+    "@comunica/actor-rdf-metadata-extract-sparql-service": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/bus-rdf-metadata-extract": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "relative-to-absolute-iri": "^1.0.5"
+      }
+    },
+    "@comunica/actor-rdf-metadata-primary-topic": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/bus-rdf-metadata": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@rdfjs/types": "*"
+      }
+    },
+    "@comunica/actor-rdf-parse-html": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/bus-rdf-parse": "^2.3.0",
+        "@comunica/bus-rdf-parse-html": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "htmlparser2": "^7.0.0"
+      }
+    },
+    "@comunica/actor-rdf-parse-html-microdata": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/bus-rdf-parse-html": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "microdata-rdf-streaming-parser": "^1.2.0"
+      }
+    },
+    "@comunica/actor-rdf-parse-html-rdfa": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/bus-rdf-parse-html": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "rdfa-streaming-parser": "^1.5.0"
+      }
+    },
+    "@comunica/actor-rdf-parse-html-script": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/bus-rdf-parse": "^2.3.0",
+        "@comunica/bus-rdf-parse-html": "^2.3.0",
+        "@comunica/context-entries": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "@rdfjs/types": "*",
+        "relative-to-absolute-iri": "^1.0.5"
+      }
+    },
+    "@comunica/actor-rdf-parse-jsonld": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/bus-http": "^2.3.0",
+        "@comunica/bus-rdf-parse": "^2.3.0",
+        "@comunica/context-entries": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "jsonld-context-parser": "^2.1.5",
+        "jsonld-streaming-parser": "^2.4.2",
+        "stream-to-string": "^1.2.0"
+      }
+    },
+    "@comunica/actor-rdf-parse-n3": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/bus-rdf-parse": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "@types/n3": "^1.4.4",
+        "n3": "^1.6.3"
+      }
+    },
+    "@comunica/actor-rdf-parse-rdfxml": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/bus-rdf-parse": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "rdfxml-streaming-parser": "^1.5.0"
+      }
+    },
+    "@comunica/actor-rdf-parse-xml-rdfa": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/bus-rdf-parse": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "rdfa-streaming-parser": "^1.5.0"
+      }
+    },
+    "@comunica/actor-rdf-resolve-hypermedia-links-next": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/bus-rdf-resolve-hypermedia-links": "^2.3.0",
+        "@comunica/core": "^2.3.0"
+      }
+    },
+    "@comunica/actor-rdf-resolve-hypermedia-links-queue-fifo": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/bus-rdf-resolve-hypermedia-links": "^2.3.0",
+        "@comunica/bus-rdf-resolve-hypermedia-links-queue": "^2.3.0",
+        "@comunica/core": "^2.3.0"
+      }
+    },
+    "@comunica/actor-rdf-resolve-hypermedia-none": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source": "^2.3.0",
+        "@comunica/bus-rdf-resolve-hypermedia": "^2.3.0",
+        "rdf-store-stream": "^1.3.0"
+      }
+    },
+    "@comunica/actor-rdf-resolve-hypermedia-qpf": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/actor-rdf-metadata-extract-hydra-controls": "^2.3.0",
+        "@comunica/bus-dereference-rdf": "^2.3.0",
+        "@comunica/bus-rdf-metadata": "^2.3.0",
+        "@comunica/bus-rdf-metadata-extract": "^2.3.0",
+        "@comunica/bus-rdf-resolve-hypermedia": "^2.3.0",
+        "@comunica/bus-rdf-resolve-quad-pattern": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.4.2",
+        "rdf-data-factory": "^1.0.3",
+        "rdf-string": "^1.5.0",
+        "rdf-terms": "^1.6.2"
+      }
+    },
+    "@comunica/actor-rdf-resolve-hypermedia-sparql": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/bindings-factory": "^2.2.0",
+        "@comunica/bus-http": "^2.3.0",
+        "@comunica/bus-rdf-resolve-hypermedia": "^2.3.0",
+        "@comunica/bus-rdf-resolve-quad-pattern": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.4.2",
+        "fetch-sparql-endpoint": "^2.3.2",
+        "rdf-data-factory": "^1.0.3",
+        "rdf-terms": "^1.6.2",
+        "sparqlalgebrajs": "^4.0.0"
+      }
+    },
+    "@comunica/actor-rdf-resolve-quad-pattern-federated": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/bus-rdf-resolve-quad-pattern": "^2.3.0",
+        "@comunica/context-entries": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/data-factory": "^2.0.1",
+        "@comunica/types": "^2.3.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.4.2",
+        "rdf-data-factory": "^1.0.3",
+        "rdf-terms": "^1.6.2",
+        "sparqlalgebrajs": "^4.0.0"
+      }
+    },
+    "@comunica/actor-rdf-resolve-quad-pattern-hypermedia": {
+      "version": "2.0.5",
+      "requires": {
+        "@comunica/actor-query-result-serialize-sparql-json": "^2.0.1",
+        "@comunica/actor-rdf-metadata-extract-hydra-controls": "^2.0.1",
+        "@comunica/bus-dereference-rdf": "^2.0.2",
+        "@comunica/bus-http-invalidate": "^2.0.1",
+        "@comunica/bus-rdf-metadata": "^2.0.1",
+        "@comunica/bus-rdf-metadata-extract": "^2.0.1",
+        "@comunica/bus-rdf-resolve-hypermedia": "^2.0.1",
+        "@comunica/bus-rdf-resolve-hypermedia-links": "^2.0.1",
+        "@comunica/bus-rdf-resolve-hypermedia-links-queue": "^2.0.1",
+        "@comunica/bus-rdf-resolve-quad-pattern": "^2.0.1",
+        "@comunica/core": "^2.0.1",
+        "@comunica/types": "^2.0.1",
+        "@rdfjs/types": "*",
+        "@types/lru-cache": "^5.1.0",
+        "asynciterator": "^3.3.0",
+        "lru-cache": "^6.0.0",
+        "rdf-data-factory": "^1.0.3",
+        "rdf-string": "^1.5.0",
+        "rdf-terms": "^1.6.2",
+        "sparqlalgebrajs": "^4.0.0"
+      }
+    },
+    "@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/bus-rdf-resolve-quad-pattern": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.4.2"
+      }
+    },
+    "@comunica/actor-rdf-serialize-jsonld": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/bus-rdf-serialize": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "jsonld-streaming-serializer": "^1.3.0"
+      }
+    },
+    "@comunica/actor-rdf-serialize-n3": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/bus-rdf-serialize": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "n3": "^1.6.3"
+      }
+    },
+    "@comunica/actor-rdf-update-hypermedia-patch-sparql-update": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/bus-http": "^2.3.0",
+        "@comunica/bus-rdf-update-hypermedia": "^2.3.0",
+        "@comunica/bus-rdf-update-quads": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.4.2",
+        "cross-fetch": "^3.0.5",
+        "rdf-string-ttl": "^1.1.0"
+      }
+    },
+    "@comunica/actor-rdf-update-hypermedia-put-ldp": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/bus-http": "^2.3.0",
+        "@comunica/bus-rdf-serialize": "^2.3.0",
+        "@comunica/bus-rdf-update-hypermedia": "^2.3.0",
+        "@comunica/bus-rdf-update-quads": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.4.2",
+        "cross-fetch": "^3.0.5"
+      }
+    },
+    "@comunica/actor-rdf-update-hypermedia-sparql": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/bus-http": "^2.3.0",
+        "@comunica/bus-rdf-update-hypermedia": "^2.3.0",
+        "@comunica/bus-rdf-update-quads": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.4.2",
+        "fetch-sparql-endpoint": "^2.3.2",
+        "rdf-string-ttl": "^1.1.0",
+        "stream-to-string": "^1.2.0"
+      }
+    },
+    "@comunica/actor-rdf-update-quads-hypermedia": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/bus-dereference-rdf": "^2.3.0",
+        "@comunica/bus-http-invalidate": "^2.3.0",
+        "@comunica/bus-rdf-metadata": "^2.3.0",
+        "@comunica/bus-rdf-metadata-extract": "^2.3.0",
+        "@comunica/bus-rdf-update-hypermedia": "^2.3.0",
+        "@comunica/bus-rdf-update-quads": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "@types/lru-cache": "^5.1.0",
+        "lru-cache": "^6.0.0"
+      }
+    },
+    "@comunica/actor-rdf-update-quads-rdfjs-store": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/bus-rdf-update-quads": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.4.2",
+        "rdf-data-factory": "^1.0.4",
+        "rdf-string": "^1.5.0"
+      }
+    },
+    "@comunica/bindings-factory": {
+      "version": "2.2.0",
+      "requires": {
+        "@rdfjs/types": "*",
+        "immutable": "^4.0.0",
+        "rdf-data-factory": "^1.1.0",
+        "rdf-string": "^1.6.0"
+      }
+    },
+    "@comunica/bus-context-preprocess": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0"
+      }
+    },
+    "@comunica/bus-dereference": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/actor-abstract-mediatyped": "^2.3.0",
+        "@comunica/actor-abstract-parse": "^2.3.0",
+        "@comunica/context-entries": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0"
+      }
+    },
+    "@comunica/bus-dereference-rdf": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/bus-dereference": "^2.3.0",
+        "@comunica/bus-rdf-parse": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@rdfjs/types": "*"
+      }
+    },
+    "@comunica/bus-hash-bindings": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0"
+      }
+    },
+    "@comunica/bus-http": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/core": "^2.3.0",
+        "is-stream": "^2.0.0",
+        "readable-web-to-node-stream": "^3.0.2",
+        "web-streams-node": "^0.4.0"
+      }
+    },
+    "@comunica/bus-http-invalidate": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/core": "^2.3.0"
+      }
+    },
+    "@comunica/bus-init": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/core": "^2.3.0"
+      }
+    },
+    "@comunica/bus-optimize-query-operation": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "sparqlalgebrajs": "^4.0.0"
+      }
+    },
+    "@comunica/bus-query-operation": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/bindings-factory": "^2.2.0",
+        "@comunica/context-entries": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/data-factory": "^2.0.1",
+        "@comunica/types": "^2.3.0",
+        "@rdfjs/types": "*",
+        "rdf-string": "^1.5.0",
+        "sparqlalgebrajs": "^4.0.0"
+      }
+    },
+    "@comunica/bus-query-parse": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/core": "^2.3.0",
+        "@rdfjs/types": "*",
+        "sparqlalgebrajs": "^4.0.0"
+      }
+    },
+    "@comunica/bus-query-result-serialize": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/actor-abstract-mediatyped": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0"
+      }
+    },
+    "@comunica/bus-rdf-join": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/bus-query-operation": "^2.3.0",
+        "@comunica/bus-rdf-join-selectivity": "^2.3.0",
+        "@comunica/context-entries": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/mediatortype-join-coefficients": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "@rdfjs/types": "*",
+        "rdf-data-factory": "^1.1.0",
+        "rdf-string": "^1.5.0"
+      }
+    },
+    "@comunica/bus-rdf-join-entries-sort": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0"
+      }
+    },
+    "@comunica/bus-rdf-join-selectivity": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/core": "^2.3.0",
+        "@comunica/mediatortype-accuracy": "^2.3.0",
+        "@comunica/types": "^2.3.0"
+      }
+    },
+    "@comunica/bus-rdf-metadata": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/core": "^2.3.0",
+        "@rdfjs/types": "*"
+      }
+    },
+    "@comunica/bus-rdf-metadata-extract": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/core": "^2.3.0",
+        "@rdfjs/types": "*"
+      }
+    },
+    "@comunica/bus-rdf-parse": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/actor-abstract-mediatyped": "^2.3.0",
+        "@comunica/actor-abstract-parse": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@rdfjs/types": "*"
+      }
+    },
+    "@comunica/bus-rdf-parse-html": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/core": "^2.3.0",
+        "@rdfjs/types": "*"
+      }
+    },
+    "@comunica/bus-rdf-resolve-hypermedia": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/bus-rdf-resolve-quad-pattern": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@rdfjs/types": "*"
+      }
+    },
+    "@comunica/bus-rdf-resolve-hypermedia-links": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "@rdfjs/types": "*"
+      }
+    },
+    "@comunica/bus-rdf-resolve-hypermedia-links-queue": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/bus-rdf-resolve-hypermedia-links": "^2.3.0",
+        "@comunica/core": "^2.3.0"
+      }
+    },
+    "@comunica/bus-rdf-resolve-quad-pattern": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/context-entries": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.4.2",
+        "sparqlalgebrajs": "^4.0.0"
+      }
+    },
+    "@comunica/bus-rdf-serialize": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/actor-abstract-mediatyped": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@rdfjs/types": "*"
+      }
+    },
+    "@comunica/bus-rdf-update-hypermedia": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/bus-rdf-update-quads": "^2.3.0",
+        "@comunica/core": "^2.3.0"
+      }
+    },
+    "@comunica/bus-rdf-update-quads": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/actor-rdf-resolve-quad-pattern-federated": "^2.3.0",
+        "@comunica/bus-http": "^2.3.0",
+        "@comunica/context-entries": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.4.2",
+        "stream-to-string": "^1.2.0"
+      }
+    },
+    "@comunica/config-query-sparql": {
+      "version": "2.2.0"
+    },
+    "@comunica/context-entries": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "@rdfjs/types": "*",
+        "jsonld-context-parser": "^2.1.5",
+        "sparqlalgebrajs": "^4.0.2"
+      }
+    },
+    "@comunica/core": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      }
+    },
+    "@comunica/data-factory": {
+      "version": "2.0.1",
+      "requires": {
+        "@rdfjs/types": "*"
+      }
+    },
+    "@comunica/logger-pretty": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/types": "^2.3.0"
+      }
+    },
+    "@comunica/logger-void": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/types": "^2.3.0"
+      }
+    },
+    "@comunica/mediator-all": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/core": "^2.3.0"
+      }
+    },
+    "@comunica/mediator-combine-pipeline": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0"
+      }
+    },
+    "@comunica/mediator-combine-union": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/core": "^2.3.0"
+      }
+    },
+    "@comunica/mediator-join-coefficients-fixed": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/bus-rdf-join": "^2.3.0",
+        "@comunica/context-entries": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/mediatortype-join-coefficients": "^2.3.0",
+        "@comunica/types": "^2.3.0"
+      }
+    },
+    "@comunica/mediator-number": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/core": "^2.3.0"
+      }
+    },
+    "@comunica/mediator-race": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/core": "^2.3.0"
+      }
+    },
+    "@comunica/mediatortype-accuracy": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/core": "^2.3.0"
+      }
+    },
+    "@comunica/mediatortype-httprequests": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/core": "^2.3.0"
+      }
+    },
+    "@comunica/mediatortype-join-coefficients": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/core": "^2.3.0",
+        "@rdfjs/types": "*"
+      }
+    },
+    "@comunica/mediatortype-time": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/core": "^2.3.0"
+      }
+    },
+    "@comunica/query-sparql-solid": {
+      "version": "2.2.0",
+      "requires": {
+        "@comunica/actor-context-preprocess-source-to-destination": "^2.0.1",
+        "@comunica/actor-dereference-fallback": "^2.0.2",
+        "@comunica/actor-dereference-http": "^2.0.2",
+        "@comunica/actor-dereference-rdf-parse": "^2.0.2",
+        "@comunica/actor-hash-bindings-sha1": "^2.0.1",
+        "@comunica/actor-http-fetch": "^2.0.1",
+        "@comunica/actor-http-inrupt-solid-client-authn": "^2.2.0",
+        "@comunica/actor-http-proxy": "^2.0.1",
+        "@comunica/actor-init-query": "^2.0.3",
+        "@comunica/actor-optimize-query-operation-bgp-to-join": "^2.0.1",
+        "@comunica/actor-optimize-query-operation-join-bgp": "^2.0.1",
+        "@comunica/actor-optimize-query-operation-join-connected": "^2.0.1",
+        "@comunica/actor-query-operation-ask": "^2.0.1",
+        "@comunica/actor-query-operation-bgp-join": "^2.0.1",
+        "@comunica/actor-query-operation-construct": "^2.0.1",
+        "@comunica/actor-query-operation-describe-subject": "^2.0.1",
+        "@comunica/actor-query-operation-distinct-hash": "^2.0.1",
+        "@comunica/actor-query-operation-extend": "^2.0.3",
+        "@comunica/actor-query-operation-filter-sparqlee": "^2.0.3",
+        "@comunica/actor-query-operation-from-quad": "^2.0.1",
+        "@comunica/actor-query-operation-group": "^2.0.3",
+        "@comunica/actor-query-operation-join": "^2.0.1",
+        "@comunica/actor-query-operation-leftjoin": "^2.0.3",
+        "@comunica/actor-query-operation-minus": "^2.0.1",
+        "@comunica/actor-query-operation-nop": "^2.0.1",
+        "@comunica/actor-query-operation-orderby-sparqlee": "^2.0.3",
+        "@comunica/actor-query-operation-path-alt": "^2.0.1",
+        "@comunica/actor-query-operation-path-inv": "^2.0.1",
+        "@comunica/actor-query-operation-path-link": "^2.0.1",
+        "@comunica/actor-query-operation-path-nps": "^2.0.1",
+        "@comunica/actor-query-operation-path-one-or-more": "^2.0.1",
+        "@comunica/actor-query-operation-path-seq": "^2.0.1",
+        "@comunica/actor-query-operation-path-zero-or-more": "^2.0.1",
+        "@comunica/actor-query-operation-path-zero-or-one": "^2.0.1",
+        "@comunica/actor-query-operation-project": "^2.0.1",
+        "@comunica/actor-query-operation-quadpattern": "^2.0.1",
+        "@comunica/actor-query-operation-reduced-hash": "^2.0.1",
+        "@comunica/actor-query-operation-service": "^2.0.1",
+        "@comunica/actor-query-operation-slice": "^2.0.1",
+        "@comunica/actor-query-operation-sparql-endpoint": "^2.0.1",
+        "@comunica/actor-query-operation-union": "^2.0.1",
+        "@comunica/actor-query-operation-update-add-rewrite": "^2.0.1",
+        "@comunica/actor-query-operation-update-clear": "^2.0.1",
+        "@comunica/actor-query-operation-update-compositeupdate": "^2.0.1",
+        "@comunica/actor-query-operation-update-copy-rewrite": "^2.0.1",
+        "@comunica/actor-query-operation-update-create": "^2.0.1",
+        "@comunica/actor-query-operation-update-deleteinsert": "^2.0.1",
+        "@comunica/actor-query-operation-update-drop": "^2.0.1",
+        "@comunica/actor-query-operation-update-load": "^2.0.1",
+        "@comunica/actor-query-operation-update-move-rewrite": "^2.0.1",
+        "@comunica/actor-query-operation-values": "^2.0.1",
+        "@comunica/actor-query-parse-graphql": "^2.0.1",
+        "@comunica/actor-query-parse-sparql": "^2.0.1",
+        "@comunica/actor-query-result-serialize-json": "^2.0.1",
+        "@comunica/actor-query-result-serialize-rdf": "^2.0.1",
+        "@comunica/actor-query-result-serialize-simple": "^2.0.1",
+        "@comunica/actor-query-result-serialize-sparql-csv": "^2.0.1",
+        "@comunica/actor-query-result-serialize-sparql-json": "^2.0.1",
+        "@comunica/actor-query-result-serialize-sparql-tsv": "^2.0.1",
+        "@comunica/actor-query-result-serialize-sparql-xml": "^2.0.1",
+        "@comunica/actor-query-result-serialize-stats": "^2.0.1",
+        "@comunica/actor-query-result-serialize-table": "^2.0.1",
+        "@comunica/actor-query-result-serialize-tree": "^2.0.1",
+        "@comunica/actor-rdf-join-entries-sort-cardinality": "^2.0.1",
+        "@comunica/actor-rdf-join-inner-hash": "^2.0.1",
+        "@comunica/actor-rdf-join-inner-multi-bind": "^2.0.1",
+        "@comunica/actor-rdf-join-inner-multi-empty": "^2.0.1",
+        "@comunica/actor-rdf-join-inner-multi-smallest": "^2.0.1",
+        "@comunica/actor-rdf-join-inner-nestedloop": "^2.0.1",
+        "@comunica/actor-rdf-join-inner-none": "^2.0.1",
+        "@comunica/actor-rdf-join-inner-single": "^2.0.1",
+        "@comunica/actor-rdf-join-inner-symmetrichash": "^2.0.1",
+        "@comunica/actor-rdf-join-minus-hash": "^2.0.1",
+        "@comunica/actor-rdf-join-minus-hash-undef": "^2.0.1",
+        "@comunica/actor-rdf-join-optional-bind": "^2.0.1",
+        "@comunica/actor-rdf-join-optional-nestedloop": "^2.0.1",
+        "@comunica/actor-rdf-join-selectivity-variable-counting": "^2.0.1",
+        "@comunica/actor-rdf-metadata-all": "^2.0.1",
+        "@comunica/actor-rdf-metadata-extract-allow-http-methods": "^2.0.1",
+        "@comunica/actor-rdf-metadata-extract-hydra-controls": "^2.0.1",
+        "@comunica/actor-rdf-metadata-extract-hydra-count": "^2.0.1",
+        "@comunica/actor-rdf-metadata-extract-hydra-pagesize": "^2.0.1",
+        "@comunica/actor-rdf-metadata-extract-patch-sparql-update": "^2.0.1",
+        "@comunica/actor-rdf-metadata-extract-put-accepted": "^2.0.1",
+        "@comunica/actor-rdf-metadata-extract-request-time": "^2.0.1",
+        "@comunica/actor-rdf-metadata-extract-sparql-service": "^2.0.1",
+        "@comunica/actor-rdf-metadata-primary-topic": "^2.0.1",
+        "@comunica/actor-rdf-parse-html": "^2.0.1",
+        "@comunica/actor-rdf-parse-html-microdata": "^2.0.1",
+        "@comunica/actor-rdf-parse-html-rdfa": "^2.0.1",
+        "@comunica/actor-rdf-parse-html-script": "^2.0.1",
+        "@comunica/actor-rdf-parse-jsonld": "^2.0.1",
+        "@comunica/actor-rdf-parse-n3": "^2.0.1",
+        "@comunica/actor-rdf-parse-rdfxml": "^2.0.1",
+        "@comunica/actor-rdf-parse-xml-rdfa": "^2.0.1",
+        "@comunica/actor-rdf-resolve-hypermedia-links-next": "^2.0.1",
+        "@comunica/actor-rdf-resolve-hypermedia-links-queue-fifo": "^2.0.1",
+        "@comunica/actor-rdf-resolve-hypermedia-none": "^2.0.1",
+        "@comunica/actor-rdf-resolve-hypermedia-qpf": "^2.0.2",
+        "@comunica/actor-rdf-resolve-hypermedia-sparql": "^2.0.1",
+        "@comunica/actor-rdf-resolve-quad-pattern-federated": "^2.0.1",
+        "@comunica/actor-rdf-resolve-quad-pattern-hypermedia": "2.0.5",
+        "@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source": "^2.0.1",
+        "@comunica/actor-rdf-serialize-jsonld": "^2.0.1",
+        "@comunica/actor-rdf-serialize-n3": "^2.0.1",
+        "@comunica/actor-rdf-update-hypermedia-patch-sparql-update": "^2.0.1",
+        "@comunica/actor-rdf-update-hypermedia-put-ldp": "^2.0.1",
+        "@comunica/actor-rdf-update-hypermedia-sparql": "^2.0.1",
+        "@comunica/actor-rdf-update-quads-hypermedia": "^2.0.2",
+        "@comunica/actor-rdf-update-quads-rdfjs-store": "^2.0.1",
+        "@comunica/bus-http-invalidate": "^2.0.1",
+        "@comunica/config-query-sparql": "^2.0.1",
+        "@comunica/context-entries": "^2.0.1",
+        "@comunica/core": "^2.0.1",
+        "@comunica/logger-void": "^2.0.1",
+        "@comunica/mediator-all": "^2.0.1",
+        "@comunica/mediator-combine-pipeline": "^2.0.1",
+        "@comunica/mediator-combine-union": "^2.0.1",
+        "@comunica/mediator-join-coefficients-fixed": "^2.0.1",
+        "@comunica/mediator-number": "^2.0.1",
+        "@comunica/mediator-race": "^2.0.1",
+        "@comunica/runner": "^2.0.3",
+        "@comunica/runner-cli": "^2.0.3",
+        "@rubensworks/solid-client-authn-isomorphic": "^2.0.0",
+        "solid-node-interactive-auth": "^1.0.1"
+      }
+    },
+    "@comunica/runner": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/bus-init": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "componentsjs": "^5.2.0"
+      }
+    },
+    "@comunica/runner-cli": {
+      "version": "2.3.0",
+      "requires": {
+        "@comunica/bus-init": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/runner": "^2.3.0",
+        "@comunica/types": "^2.3.0"
+      }
+    },
+    "@comunica/types": {
+      "version": "2.3.0",
+      "requires": {
+        "@rdfjs/types": "*",
+        "@types/yargs": "^17.0.2",
+        "asynciterator": "^3.4.2",
+        "sparqlalgebrajs": "^4.0.0"
+      }
+    },
     "@cspotcode/source-map-support": {
       "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
-      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
       "dev": true,
       "requires": {
         "@jridgewell/trace-mapping": "0.3.9"
       }
     },
+    "@dabh/diagnostics": {
+      "version": "2.0.3",
+      "requires": {
+        "colorspace": "1.1.x",
+        "enabled": "2.0.x",
+        "kuler": "^2.0.0"
+      }
+    },
     "@digitalbazaar/http-client": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@digitalbazaar/http-client/-/http-client-1.2.0.tgz",
-      "integrity": "sha512-W9KQQ5pUJcaR0I4c2HPJC0a7kRbZApIorZgPnEDwMBgj16iQzutGLrCXYaZOmxqVLVNqqlQ4aUJh+HBQZy4W6Q==",
       "requires": {
         "esm": "^3.2.22",
         "ky": "^0.25.1",
@@ -5401,8 +9561,6 @@
     },
     "@eslint/eslintrc": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.0.tgz",
-      "integrity": "sha512-UWW0TMTmk2d7hLcWD1/e2g5HDM/HQ3csaLSqXCfqwh4uNDuNqlaKWXmEsL4Cs41Z0KnILNvwbHAah3C2yt06kw==",
       "dev": true,
       "requires": {
         "ajv": "^6.12.4",
@@ -5418,8 +9576,6 @@
     },
     "@humanwhocodes/config-array": {
       "version": "0.10.4",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.10.4.tgz",
-      "integrity": "sha512-mXAIHxZT3Vcpg83opl1wGlVZ9xydbfZO3r5YfRSH6Gpp2J/PfdBP0wbDa2sO6/qRbcalpoevVyW6A/fI6LfeMw==",
       "dev": true,
       "requires": {
         "@humanwhocodes/object-schema": "^1.2.1",
@@ -5429,20 +9585,35 @@
     },
     "@humanwhocodes/gitignore-to-minimatch": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/gitignore-to-minimatch/-/gitignore-to-minimatch-1.0.2.tgz",
-      "integrity": "sha512-rSqmMJDdLFUsyxR6FMtD00nfQKKLFb1kv+qBbOVKqErvloEIJLo5bDTJTQNTYgeyp78JsA7u/NPi5jT1GR/MuA==",
       "dev": true
     },
     "@humanwhocodes/object-schema": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
-      "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
       "dev": true
+    },
+    "@inrupt/oidc-client": {
+      "version": "1.11.6",
+      "requires": {
+        "acorn": "^7.4.1",
+        "base64-js": "^1.5.1",
+        "core-js": "^3.8.3",
+        "crypto-js": "^4.0.0",
+        "serialize-javascript": "^4.0.0"
+      }
+    },
+    "@inrupt/oidc-client-ext": {
+      "version": "1.12.2",
+      "requires": {
+        "@inrupt/oidc-client": "^1.11.6",
+        "@inrupt/solid-client-authn-core": "^1.12.2",
+        "@types/jest": "^27.0.3",
+        "@types/uuid": "^8.3.0",
+        "jose": "^4.3.7",
+        "uuid": "^8.3.1"
+      }
     },
     "@inrupt/solid-client": {
       "version": "1.23.1",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-client/-/solid-client-1.23.1.tgz",
-      "integrity": "sha512-M1MyS0Qd9FjedppFctnpfAO8x046VIcmFOt9SHU3/1aDTGQrgNIqGeIBRCDwUvCRVvfvmpYE9Q9BdnA2gHAgzQ==",
       "requires": {
         "@rdfjs/dataset": "^1.1.0",
         "@rdfjs/types": "^1.1.0",
@@ -5454,10 +9625,22 @@
         "n3": "^1.10.0"
       }
     },
+    "@inrupt/solid-client-authn-browser": {
+      "version": "1.12.2",
+      "requires": {
+        "@inrupt/oidc-client-ext": "^1.12.2",
+        "@inrupt/solid-client-authn-core": "^1.12.2",
+        "@types/lodash.clonedeep": "^4.5.6",
+        "@types/node": "^18.0.3",
+        "@types/uuid": "^8.3.0",
+        "events": "^3.3.0",
+        "jose": "^4.3.7",
+        "lodash.clonedeep": "^4.5.0",
+        "uuid": "^8.3.1"
+      }
+    },
     "@inrupt/solid-client-authn-core": {
       "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-core/-/solid-client-authn-core-1.12.2.tgz",
-      "integrity": "sha512-UitzMHfUKVHy5ogYgdRLo82CUkHrFLJfnYH8jxpELEK+EzOg3zDT0vmNyNjpZ9vL9th9BOzy8RBuwWusZuo/wg==",
       "requires": {
         "@inrupt/solid-common-vocab": "^1.0.0",
         "@types/lodash.clonedeep": "^4.5.6",
@@ -5471,8 +9654,6 @@
     },
     "@inrupt/solid-client-authn-node": {
       "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-node/-/solid-client-authn-node-1.12.2.tgz",
-      "integrity": "sha512-w7RLSMz87gJ+5xUFoH/XfKTC05kipJr5kjfJdezKrGr1RhrbLu1byPWn5iW+tfANuWtvlsXIHhEJxG7YW1Q2bQ==",
       "requires": {
         "@inrupt/solid-client-authn-core": "^1.12.2",
         "cross-fetch": "^3.1.5",
@@ -5483,33 +9664,23 @@
     },
     "@inrupt/solid-common-vocab": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-common-vocab/-/solid-common-vocab-1.0.1.tgz",
-      "integrity": "sha512-daCb8amQHzfB9N5bop3enur6l6UHjt9/fxvC8Or9wdzybAGMSF7UcrW3Pr/MM5H0GOKrVBczlxR4t6sMWgul1g==",
       "requires": {
         "@rdfjs/types": "^1.1.0"
       }
     },
     "@inrupt/vocab-common-rdf": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@inrupt/vocab-common-rdf/-/vocab-common-rdf-1.0.5.tgz",
-      "integrity": "sha512-onrehQte8m0XW83WwM6T4o5WgmYGzdYUCef6FDjMKfQCF64FnARFNn5fYhKodimBaAOFKhuJ3vw1NBZV/EYqJw=="
+      "version": "1.0.5"
     },
     "@jridgewell/resolve-uri": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.8.tgz",
-      "integrity": "sha512-YK5G9LaddzGbcucK4c8h5tWFmMPBvRZ/uyWmN1/SbBdIvqGUdWGkJ5BAaccgs6XbzVLsqbPJrBSFwKv3kT9i7w==",
+      "version": "3.1.0",
       "dev": true
     },
     "@jridgewell/sourcemap-codec": {
       "version": "1.4.14",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
       "dev": true
     },
     "@jridgewell/trace-mapping": {
       "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
-      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
       "dev": true,
       "requires": {
         "@jridgewell/resolve-uri": "^3.0.3",
@@ -5518,8 +9689,6 @@
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
-      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
       "dev": true,
       "requires": {
         "@nodelib/fs.stat": "2.0.5",
@@ -5528,14 +9697,10 @@
     },
     "@nodelib/fs.stat": {
       "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
       "dev": true
     },
     "@nodelib/fs.walk": {
       "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
-      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
       "dev": true,
       "requires": {
         "@nodelib/fs.scandir": "2.1.5",
@@ -5544,16 +9709,12 @@
     },
     "@rdfjs/data-model": {
       "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/@rdfjs/data-model/-/data-model-1.3.4.tgz",
-      "integrity": "sha512-iKzNcKvJotgbFDdti7GTQDCYmL7GsGldkYStiP0K8EYtN7deJu5t7U11rKTz+nR7RtesUggT+lriZ7BakFv8QQ==",
       "requires": {
         "@rdfjs/types": ">=1.0.1"
       }
     },
     "@rdfjs/dataset": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@rdfjs/dataset/-/dataset-1.1.1.tgz",
-      "integrity": "sha512-BNwCSvG0cz0srsG5esq6CQKJc1m8g/M0DZpLuiEp0MMpfwguXX7VeS8TCg4UUG3DV/DqEvhy83ZKSEjdsYseeA==",
       "requires": {
         "@rdfjs/data-model": "^1.2.0"
       }
@@ -5566,10 +9727,16 @@
         "@types/node": "*"
       }
     },
+    "@rubensworks/solid-client-authn-isomorphic": {
+      "version": "2.0.0",
+      "requires": {
+        "@inrupt/solid-client-authn-browser": "^1.12.1",
+        "@inrupt/solid-client-authn-core": "^1.12.1",
+        "@inrupt/solid-client-authn-node": "^1.12.1"
+      }
+    },
     "@sinonjs/commons": {
       "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
-      "integrity": "sha512-xkNcLAn/wZaX14RPlwizcKicDk9G3F8m2nU3L7Ukm5zBgTwiT0wsoFAHx9Jq56fJA1z/7uKGtCRu16sOUCLIHQ==",
       "dev": true,
       "requires": {
         "type-detect": "4.0.8"
@@ -5577,8 +9744,6 @@
     },
     "@sinonjs/fake-timers": {
       "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-9.1.2.tgz",
-      "integrity": "sha512-BPS4ynJW/o92PUR4wgriz2Ud5gpST5vz6GQfMixEDK0Z8ZCUv2M7SkBLykH56T++Xs+8ln9zTGbOvNGIe02/jw==",
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.7.0"
@@ -5586,8 +9751,6 @@
     },
     "@sinonjs/samsam": {
       "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-6.1.1.tgz",
-      "integrity": "sha512-cZ7rKJTLiE7u7Wi/v9Hc2fs3Ucc3jrWeMgPHbbTCeVAB2S0wOBbYlkJVeNSL04i7fdhT8wIbDq1zhC/PXTD2SA==",
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.6.0",
@@ -5596,39 +9759,27 @@
       }
     },
     "@sinonjs/text-encoding": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
-      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
+      "version": "0.7.2",
       "dev": true
     },
     "@tsconfig/node10": {
       "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
-      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
       "dev": true
     },
     "@tsconfig/node12": {
       "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
-      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
       "dev": true
     },
     "@tsconfig/node14": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
-      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
       "dev": true
     },
     "@tsconfig/node16": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
-      "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
       "dev": true
     },
     "@types/body-parser": {
       "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
-      "integrity": "sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==",
       "dev": true,
       "requires": {
         "@types/connect": "*",
@@ -5643,8 +9794,6 @@
     },
     "@types/connect": {
       "version": "3.4.35",
-      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
-      "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -5652,8 +9801,6 @@
     },
     "@types/cookie-parser": {
       "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/@types/cookie-parser/-/cookie-parser-1.4.3.tgz",
-      "integrity": "sha512-CqSKwFwefj4PzZ5n/iwad/bow2hTCh0FlNAeWLtQM3JA/NX/iYagIpWG2cf1bQKQ2c9gU2log5VUCrn7LDOs0w==",
       "dev": true,
       "requires": {
         "@types/express": "*"
@@ -5661,8 +9808,6 @@
     },
     "@types/cookie-session": {
       "version": "2.0.44",
-      "resolved": "https://registry.npmjs.org/@types/cookie-session/-/cookie-session-2.0.44.tgz",
-      "integrity": "sha512-3DheOZ41pql6raSIkqEPphJdhA2dX2bkS+s2Qacv8YMKkoCbAIEXbsDil7351ARzMqvfyDUGNeHGiRZveIzhqQ==",
       "dev": true,
       "requires": {
         "@types/express": "*",
@@ -5671,8 +9816,6 @@
     },
     "@types/express": {
       "version": "4.17.13",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
-      "integrity": "sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==",
       "dev": true,
       "requires": {
         "@types/body-parser": "*",
@@ -5682,9 +9825,7 @@
       }
     },
     "@types/express-serve-static-core": {
-      "version": "4.17.29",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.29.tgz",
-      "integrity": "sha512-uMd++6dMKS32EOuw1Uli3e3BPgdLIXmezcfHv7N4c1s3gkhikBplORPpMq3fuWkxncZN1reb16d5n8yhQ80x7Q==",
+      "version": "4.17.30",
       "dev": true,
       "requires": {
         "@types/node": "*",
@@ -5694,17 +9835,26 @@
     },
     "@types/http-errors": {
       "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-1.8.2.tgz",
-      "integrity": "sha512-EqX+YQxINb+MeXaIqYDASb6U6FCHbWjkj4a1CKDBks3d/QiB2+PqBLyO72vLDgAO1wUI4O+9gweRcQK11bTL/w==",
       "dev": true
+    },
+    "@types/http-link-header": {
+      "version": "1.0.3",
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/i18next-fs-backend": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@types/i18next-fs-backend/-/i18next-fs-backend-1.1.2.tgz",
-      "integrity": "sha512-ZzTRXA5B0x0oGhzKNp08IsYjZpli4LjRZpg3q4j0XFxN5lKG2MVLnR4yHX8PPExBk4sj9Yfk1z9O6CjPrAlmIQ==",
       "dev": true,
       "requires": {
         "i18next": "^21.0.1"
+      }
+    },
+    "@types/jest": {
+      "version": "27.5.2",
+      "requires": {
+        "jest-matcher-utils": "^27.0.0",
+        "pretty-format": "^27.0.0"
       }
     },
     "@types/json-schema": {
@@ -5730,39 +9880,33 @@
     },
     "@types/keygrip": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@types/keygrip/-/keygrip-1.0.2.tgz",
-      "integrity": "sha512-GJhpTepz2udxGexqos8wgaBx4I/zWIDPh/KOGEwAqtuGDkOUJu5eFvwmdBX4AmB8Odsr+9pHCQqiAqDL/yKMKw==",
       "dev": true
     },
     "@types/lodash": {
-      "version": "4.14.182",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.182.tgz",
-      "integrity": "sha512-/THyiqyQAP9AfARo4pF+aCGcyiQ94tX/Is2I7HofNRqoYLgN1PBoOWu2/zTA5zMxzP5EFutMtWtGAFRKUe961Q=="
+      "version": "4.14.182"
     },
     "@types/lodash.clonedeep": {
       "version": "4.5.7",
-      "resolved": "https://registry.npmjs.org/@types/lodash.clonedeep/-/lodash.clonedeep-4.5.7.tgz",
-      "integrity": "sha512-ccNqkPptFIXrpVqUECi60/DFxjNKsfoQxSQsgcBJCX/fuX1wgyQieojkcWH/KpE3xzLoWN/2k+ZeGqIN3paSvw==",
       "requires": {
         "@types/lodash": "*"
       }
     },
+    "@types/lru-cache": {
+      "version": "5.1.1"
+    },
     "@types/mime": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
-      "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==",
+      "version": "3.0.0",
       "dev": true
+    },
+    "@types/minimist": {
+      "version": "1.2.2"
     },
     "@types/mocha": {
       "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.1.1.tgz",
-      "integrity": "sha512-Z61JK7DKDtdKTWwLeElSEBcWGRLY8g95ic5FoQqI9CMx0ns/Ghep3B4DfcEimiKMvtamNVULVNKEsiwV3aQmXw==",
       "dev": true
     },
     "@types/morgan": {
       "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/@types/morgan/-/morgan-1.9.3.tgz",
-      "integrity": "sha512-BiLcfVqGBZCyNCnCH3F4o2GmDLrpy0HeBVnNlyZG4fo88ZiE9SoiBe3C+2ezuwbjlEyT+PDZ17//TAlRxAn75Q==",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -5770,8 +9914,6 @@
     },
     "@types/n3": {
       "version": "1.10.4",
-      "resolved": "https://registry.npmjs.org/@types/n3/-/n3-1.10.4.tgz",
-      "integrity": "sha512-FfRTwcbXcScVHuAjIASveRWL6Fi6fPALl1Ge8tMESYLqU7R42LJvtdBpUi+f9YK0oQPqIN+zFFgMDFJfLMx0bg==",
       "requires": {
         "@types/node": "*",
         "rdf-js": "^4.0.2"
@@ -5784,44 +9926,42 @@
     },
     "@types/nunjucks": {
       "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@types/nunjucks/-/nunjucks-3.2.1.tgz",
-      "integrity": "sha512-hUh5HIC7peH+0MvlYU5KM2RydWxG1mBceivHsQGwlelU9zlczLICyJmjMwgjkI3m0+N50n46GVHkw35lIim6LQ==",
       "dev": true
     },
     "@types/qs": {
       "version": "6.9.7",
-      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
-      "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==",
       "dev": true
     },
     "@types/range-parser": {
       "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
-      "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
       "dev": true
     },
     "@types/rdfjs__dataset": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@types/rdfjs__dataset/-/rdfjs__dataset-1.0.5.tgz",
-      "integrity": "sha512-8OBC9Kr/ZSgNoUTe5mHTDPHaPt8Xen4XbYfqcbYv56d+4WdKliHXaFmFc0L4I5vsynE5JGu21Hvg2zWgX1Az6Q==",
       "requires": {
         "rdf-js": "^4.0.2"
       }
     },
+    "@types/readable-stream": {
+      "version": "2.3.14",
+      "requires": {
+        "@types/node": "*",
+        "safe-buffer": "*"
+      }
+    },
+    "@types/semver": {
+      "version": "7.3.10"
+    },
     "@types/serve-static": {
-      "version": "1.13.10",
-      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.10.tgz",
-      "integrity": "sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==",
+      "version": "1.15.0",
       "dev": true,
       "requires": {
-        "@types/mime": "^1",
+        "@types/mime": "*",
         "@types/node": "*"
       }
     },
     "@types/sinon": {
       "version": "10.0.13",
-      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-10.0.13.tgz",
-      "integrity": "sha512-UVjDqJblVNQYvVNUsj0PuYYw0ELRmgt1Nt5Vk0pT5f16ROGfcKJY8o1HVuMOJOpD727RrGB9EGvoaTQE5tgxZQ==",
       "dev": true,
       "requires": {
         "@types/sinonjs__fake-timers": "*"
@@ -5829,8 +9969,6 @@
     },
     "@types/sinon-chai": {
       "version": "3.2.8",
-      "resolved": "https://registry.npmjs.org/@types/sinon-chai/-/sinon-chai-3.2.8.tgz",
-      "integrity": "sha512-d4ImIQbT/rKMG8+AXpmcan5T2/PNeSjrYhvkwet6z0p8kzYtfgA32xzOBlbU0yqJfq+/0Ml805iFoODO0LP5/g==",
       "dev": true,
       "requires": {
         "@types/chai": "*",
@@ -5839,14 +9977,31 @@
     },
     "@types/sinonjs__fake-timers": {
       "version": "8.1.2",
-      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.2.tgz",
-      "integrity": "sha512-9GcLXF0/v3t80caGs5p2rRfkB+a8VBGLJZVih6CNFkx8IZ994wiKKLSRs9nuFwk1HevWs/1mnUmkApGrSGsShA==",
       "dev": true
     },
+    "@types/spark-md5": {
+      "version": "3.0.2"
+    },
+    "@types/sparqljs": {
+      "version": "3.1.3",
+      "requires": {
+        "rdf-js": "^4.0.2"
+      }
+    },
+    "@types/uritemplate": {
+      "version": "0.3.4"
+    },
     "@types/uuid": {
-      "version": "8.3.4",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
-      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw=="
+      "version": "8.3.4"
+    },
+    "@types/yargs": {
+      "version": "17.0.10",
+      "requires": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "@types/yargs-parser": {
+      "version": "21.0.0"
     },
     "@typescript-eslint/eslint-plugin": {
       "version": "5.33.0",
@@ -5863,17 +10018,6 @@
         "regexpp": "^3.2.0",
         "semver": "^7.3.7",
         "tsutils": "^3.21.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "7.3.7",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        }
       }
     },
     "@typescript-eslint/parser": {
@@ -5928,17 +10072,6 @@
         "is-glob": "^4.0.3",
         "semver": "^7.3.7",
         "tsutils": "^3.21.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "7.3.7",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        }
       }
     },
     "@typescript-eslint/utils": {
@@ -5953,24 +10086,6 @@
         "@typescript-eslint/typescript-estree": "5.33.0",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0"
-      },
-      "dependencies": {
-        "eslint-scope": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
-          "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
-          "dev": true,
-          "requires": {
-            "esrecurse": "^4.3.0",
-            "estraverse": "^4.1.1"
-          }
-        },
-        "estraverse": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-          "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-          "dev": true
-        }
       }
     },
     "@typescript-eslint/visitor-keys": {
@@ -5985,61 +10100,42 @@
     },
     "@ungap/promise-all-settled": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
-      "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
       "dev": true
     },
     "a-sync-waterfall": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/a-sync-waterfall/-/a-sync-waterfall-1.0.1.tgz",
-      "integrity": "sha512-RYTOHHdWipFUliRFMCS4X2Yn2X8M87V/OpSqWzKKOGhzqyUxzyVmhHDH9sAvG+ZuQf/TAOFsLCpMw09I1ufUnA=="
+      "version": "1.0.1"
     },
     "abbrev": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
       "dev": true
     },
     "abort-controller": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
-      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
       "requires": {
         "event-target-shim": "^5.0.0"
       }
     },
     "accepts": {
       "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
-      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
       "requires": {
         "mime-types": "~2.1.34",
         "negotiator": "0.6.3"
       }
     },
     "acorn": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
-      "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
-      "dev": true
+      "version": "7.4.1"
     },
     "acorn-jsx": {
       "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
-      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "dev": true,
       "requires": {}
     },
     "acorn-walk": {
       "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
-      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
       "dev": true
     },
     "ajv": {
       "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
@@ -6050,29 +10146,19 @@
     },
     "ansi-colors": {
       "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
-      "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
       "dev": true
     },
     "ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true
+      "version": "5.0.1"
     },
     "ansi-styles": {
       "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "requires": {
         "color-convert": "^2.0.1"
       }
     },
     "anymatch": {
       "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
-      "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
       "devOptional": true,
       "requires": {
         "normalize-path": "^3.0.0",
@@ -6081,14 +10167,10 @@
     },
     "arg": {
       "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
       "dev": true
     },
     "argparse": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
     },
     "aria-query": {
@@ -6102,9 +10184,7 @@
       }
     },
     "array-flatten": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="
+      "version": "1.1.1"
     },
     "array-includes": {
       "version": "3.1.5",
@@ -6121,8 +10201,6 @@
     },
     "array-union": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
       "dev": true
     },
     "array.prototype.flat": {
@@ -6150,14 +10228,10 @@
       }
     },
     "asap": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="
+      "version": "2.0.6"
     },
     "assertion-error": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
       "dev": true
     },
     "ast-types-flow": {
@@ -6165,6 +10239,18 @@
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
       "integrity": "sha512-eBvWn1lvIApYMhzQMsu9ciLfkBY499mFZlNqG+/9WR7PVlroQw0vG30cOQQbaKz3sCEc44TAOu2ykzqXSNnwag==",
       "dev": true
+    },
+    "async": {
+      "version": "3.2.4"
+    },
+    "asynciterator": {
+      "version": "3.6.0"
+    },
+    "asyncjoin": {
+      "version": "1.0.6",
+      "requires": {
+        "asynciterator": "^3.2.0"
+      }
     },
     "axe-core": {
       "version": "4.4.3",
@@ -6180,35 +10266,31 @@
     },
     "balanced-match": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
+    },
+    "base64-js": {
+      "version": "1.5.1"
     },
     "basic-auth": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
-      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
       "requires": {
         "safe-buffer": "5.1.2"
       },
       "dependencies": {
         "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+          "version": "5.1.2"
         }
       }
     },
+    "bignumber.js": {
+      "version": "9.0.2"
+    },
     "binary-extensions": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
-      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
       "devOptional": true
     },
     "body-parser": {
       "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.0.tgz",
-      "integrity": "sha512-DfJ+q6EPcGKZD1QWUjSpqp+Q7bDQTsQIF4zfUAtZ6qk+H/3/QRhg9CEp39ss+/T2vw0+HaidC0ecJj/DRLIaKg==",
       "requires": {
         "bytes": "3.1.2",
         "content-type": "~1.0.4",
@@ -6226,23 +10308,17 @@
       "dependencies": {
         "debug": {
           "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "requires": {
             "ms": "2.0.0"
           }
         },
         "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+          "version": "2.0.0"
         }
       }
     },
     "brace-expansion": {
       "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
@@ -6251,8 +10327,6 @@
     },
     "braces": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
       "devOptional": true,
       "requires": {
         "fill-range": "^7.0.1"
@@ -6260,8 +10334,6 @@
     },
     "browser-stdout": {
       "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
-      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
     },
     "buffer-equal-constant-time": {
@@ -6270,14 +10342,10 @@
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
     },
     "bytes": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
-      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="
+      "version": "3.1.2"
     },
     "call-bind": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
       "requires": {
         "function-bind": "^1.1.1",
         "get-intrinsic": "^1.0.2"
@@ -6285,25 +10353,17 @@
     },
     "callsites": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "dev": true
     },
     "camelcase": {
       "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
-      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
       "dev": true
     },
     "canonicalize": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/canonicalize/-/canonicalize-1.0.8.tgz",
-      "integrity": "sha512-0CNTVCLZggSh7bc5VkX5WWPWO+cyZbNd07IHIsSXLia/eAq+r836hgk+8BKoEh7949Mda87VUOitx5OddVj64A=="
+      "version": "1.0.8"
     },
     "chai": {
       "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.6.tgz",
-      "integrity": "sha512-bbcp3YfHCUzMOvKqsztczerVgBKSsEijCySNlHHbX3VG1nskvqjz5Rfso1gGwD6w6oOV3eI60pKuMOV5MV7p3Q==",
       "dev": true,
       "requires": {
         "assertion-error": "^1.1.0",
@@ -6317,9 +10377,6 @@
     },
     "chalk": {
       "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
       "requires": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -6327,14 +10384,10 @@
     },
     "check-error": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
-      "integrity": "sha512-BrgHpW9NURQgzoNyjfq0Wu6VFO6D7IZEmJNdtgNqpzGG8RuNFHt2jQxWlAs4HMe119chBnv+34syEZtc6IhLtA==",
       "dev": true
     },
     "chokidar": {
       "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
-      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
       "devOptional": true,
       "requires": {
         "anymatch": "~3.1.2",
@@ -6345,43 +10398,95 @@
         "is-glob": "~4.0.1",
         "normalize-path": "~3.0.0",
         "readdirp": "~3.6.0"
+      },
+      "dependencies": {
+        "glob-parent": {
+          "version": "5.1.2",
+          "devOptional": true,
+          "requires": {
+            "is-glob": "^4.0.1"
+          }
+        }
       }
     },
     "cliui": {
       "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
-      "dev": true,
       "requires": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
         "wrap-ansi": "^7.0.0"
       }
     },
+    "color": {
+      "version": "3.2.1",
+      "requires": {
+        "color-convert": "^1.9.3",
+        "color-string": "^1.6.0"
+      },
+      "dependencies": {
+        "color-convert": {
+          "version": "1.9.3",
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3"
+        }
+      }
+    },
     "color-convert": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "requires": {
         "color-name": "~1.1.4"
       }
     },
     "color-name": {
+      "version": "1.1.4"
+    },
+    "color-string": {
+      "version": "1.9.1",
+      "requires": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
+    },
+    "colorspace": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
+      "requires": {
+        "color": "^3.1.3",
+        "text-hex": "1.0.x"
+      }
     },
     "commander": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
-      "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg=="
+      "version": "5.1.0"
+    },
+    "componentsjs": {
+      "version": "5.2.0",
+      "requires": {
+        "@rdfjs/types": "*",
+        "@types/minimist": "^1.2.0",
+        "@types/node": "^14.14.7",
+        "@types/semver": "^7.3.4",
+        "jsonld-context-parser": "^2.1.1",
+        "minimist": "^1.2.0",
+        "rdf-data-factory": "^1.1.0",
+        "rdf-object": "^1.13.1",
+        "rdf-parse": "^2.0.0",
+        "rdf-quad": "^1.5.0",
+        "rdf-string": "^1.6.0",
+        "rdf-terms": "^1.7.0",
+        "semver": "^7.3.2",
+        "winston": "^3.3.3"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "14.18.23"
+        }
+      }
     },
     "concat-map": {
       "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
     },
     "confusing-browser-globals": {
@@ -6392,26 +10497,18 @@
     },
     "content-disposition": {
       "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
-      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
       "requires": {
         "safe-buffer": "5.2.1"
       }
     },
     "content-type": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
+      "version": "1.0.4"
     },
     "cookie": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
-      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA=="
+      "version": "0.4.1"
     },
     "cookie-parser": {
       "version": "1.4.6",
-      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
-      "integrity": "sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==",
       "requires": {
         "cookie": "0.4.1",
         "cookie-signature": "1.0.6"
@@ -6419,8 +10516,6 @@
     },
     "cookie-session": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/cookie-session/-/cookie-session-2.0.0.tgz",
-      "integrity": "sha512-hKvgoThbw00zQOleSlUr2qpvuNweoqBtxrmx0UFosx6AGi9lYtLoA+RbsvknrEX8Pr6MDbdWAb2j6SnMn+lPsg==",
       "requires": {
         "cookies": "0.8.0",
         "debug": "3.2.7",
@@ -6430,8 +10525,6 @@
       "dependencies": {
         "debug": {
           "version": "3.2.7",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
           "requires": {
             "ms": "^2.1.1"
           }
@@ -6439,49 +10532,45 @@
       }
     },
     "cookie-signature": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
+      "version": "1.0.6"
     },
     "cookies": {
       "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/cookies/-/cookies-0.8.0.tgz",
-      "integrity": "sha512-8aPsApQfebXnuI+537McwYsDtjVxGm8gTIzQI3FDW6t5t/DAhERxtnbEPN/8RX+uZthoz4eCOgloXaE5cYyNow==",
       "requires": {
         "depd": "~2.0.0",
         "keygrip": "~1.1.0"
       }
     },
+    "core-js": {
+      "version": "3.24.1"
+    },
     "core-js-pure": {
-      "version": "3.24.0",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.24.0.tgz",
-      "integrity": "sha512-uzMmW8cRh7uYw4JQtzqvGWRyC2T5+4zipQLQdi2FmiRqP83k3d6F3stv2iAlNhOs6cXN401FCD5TL0vvleuHgA==",
+      "version": "3.24.1",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.24.1.tgz",
+      "integrity": "sha512-r1nJk41QLLPyozHUUPmILCEMtMw24NG4oWK6RbsDdjzQgg9ZvrUsPBj1MnG0wXXp1DCDU6j+wUvEmBSrtRbLXg==",
       "dev": true
     },
     "create-require": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
     },
     "cross-fetch": {
       "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
-      "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
       "requires": {
         "node-fetch": "2.6.7"
       }
     },
     "cross-spawn": {
       "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
       "dev": true,
       "requires": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
         "which": "^2.0.1"
       }
+    },
+    "crypto-js": {
+      "version": "4.1.1"
     },
     "damerau-levenshtein": {
       "version": "1.0.8",
@@ -6490,35 +10579,20 @@
       "dev": true
     },
     "data-uri-to-buffer": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-3.0.1.tgz",
-      "integrity": "sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og=="
+      "version": "3.0.1"
     },
     "debug": {
       "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "requires": {
         "ms": "2.1.2"
-      },
-      "dependencies": {
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        }
       }
     },
     "decamelize": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
-      "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
       "dev": true
     },
     "deep-eql": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
-      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
       "dev": true,
       "requires": {
         "type-detect": "^4.0.0"
@@ -6526,9 +10600,10 @@
     },
     "deep-is": {
       "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
-      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
+    },
+    "define-lazy-prop": {
+      "version": "2.0.0"
     },
     "define-properties": {
       "version": "1.1.4",
@@ -6541,25 +10616,20 @@
       }
     },
     "depd": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
-      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
+      "version": "2.0.0"
     },
     "destroy": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
-      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg=="
+      "version": "1.2.0"
     },
     "diff": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
-      "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
       "dev": true
+    },
+    "diff-sequences": {
+      "version": "27.5.1"
     },
     "dir-glob": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
-      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
       "dev": true,
       "requires": {
         "path-type": "^4.0.0"
@@ -6567,11 +10637,39 @@
     },
     "doctrine": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
-      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
       "dev": true,
       "requires": {
         "esutils": "^2.0.2"
+      }
+    },
+    "dom-serializer": {
+      "version": "1.4.1",
+      "requires": {
+        "domelementtype": "^2.0.1",
+        "domhandler": "^4.2.0",
+        "entities": "^2.0.0"
+      },
+      "dependencies": {
+        "entities": {
+          "version": "2.2.0"
+        }
+      }
+    },
+    "domelementtype": {
+      "version": "2.3.0"
+    },
+    "domhandler": {
+      "version": "4.3.1",
+      "requires": {
+        "domelementtype": "^2.2.0"
+      }
+    },
+    "domutils": {
+      "version": "2.8.0",
+      "requires": {
+        "dom-serializer": "^1.0.1",
+        "domelementtype": "^2.2.0",
+        "domhandler": "^4.2.0"
       }
     },
     "ecdsa-sig-formatter": {
@@ -6583,20 +10681,19 @@
       }
     },
     "ee-first": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
+      "version": "1.1.1"
     },
     "emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true
+      "version": "8.0.0"
+    },
+    "enabled": {
+      "version": "2.0.0"
     },
     "encodeurl": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w=="
+      "version": "1.0.2"
+    },
+    "entities": {
+      "version": "3.0.1"
     },
     "es-abstract": {
       "version": "1.20.1",
@@ -6650,26 +10747,17 @@
       }
     },
     "escalade": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
-      "dev": true
+      "version": "3.1.1"
     },
     "escape-html": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="
+      "version": "1.0.3"
     },
     "escape-string-regexp": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
       "dev": true
     },
     "eslint": {
       "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.21.0.tgz",
-      "integrity": "sha512-/XJ1+Qurf1T9G2M5IHrsjp+xrGT73RZf23xA1z5wB1ZzzEAWSZKvRwhWxTFp1rvkvCfwcvAUNAP31bhKTTGfDA==",
       "dev": true,
       "requires": {
         "@eslint/eslintrc": "^1.3.0",
@@ -6713,13 +10801,12 @@
         "v8-compile-cache": "^2.0.3"
       },
       "dependencies": {
-        "glob-parent": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
-          "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+        "eslint-scope": {
+          "version": "7.1.1",
           "dev": true,
           "requires": {
-            "is-glob": "^4.0.3"
+            "esrecurse": "^4.3.0",
+            "estraverse": "^5.2.0"
           }
         }
       }
@@ -6996,19 +11083,25 @@
       "requires": {}
     },
     "eslint-scope": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
-      "integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
       "dev": true,
       "requires": {
         "esrecurse": "^4.3.0",
-        "estraverse": "^5.2.0"
+        "estraverse": "^4.1.1"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+          "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+          "dev": true
+        }
       }
     },
     "eslint-utils": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
-      "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
       "dev": true,
       "requires": {
         "eslint-visitor-keys": "^2.0.0"
@@ -7016,38 +11109,34 @@
       "dependencies": {
         "eslint-visitor-keys": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
-          "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
           "dev": true
         }
       }
     },
     "eslint-visitor-keys": {
       "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
-      "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
       "dev": true
     },
     "esm": {
-      "version": "3.2.25",
-      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
-      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA=="
+      "version": "3.2.25"
     },
     "espree": {
       "version": "9.3.3",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-9.3.3.tgz",
-      "integrity": "sha512-ORs1Rt/uQTqUKjDdGCyrtYxbazf5umATSf/K4qxjmZHORR6HJk+2s/2Pqe+Kk49HHINC/xNIrGfgh8sZcll0ng==",
       "dev": true,
       "requires": {
         "acorn": "^8.8.0",
         "acorn-jsx": "^5.3.2",
         "eslint-visitor-keys": "^3.3.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "8.8.0",
+          "dev": true
+        }
       }
     },
     "esquery": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
-      "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
       "dev": true,
       "requires": {
         "estraverse": "^5.1.0"
@@ -7055,8 +11144,6 @@
     },
     "esrecurse": {
       "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
-      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
       "dev": true,
       "requires": {
         "estraverse": "^5.2.0"
@@ -7070,29 +11157,19 @@
     },
     "esutils": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
     },
     "etag": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="
+      "version": "1.8.1"
     },
     "event-target-shim": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
+      "version": "5.0.1"
     },
     "events": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
-      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="
+      "version": "3.3.0"
     },
     "express": {
       "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.18.1.tgz",
-      "integrity": "sha512-zZBcOX9TfehHQhtupq57OF8lFZ3UZi08Y97dwFCkD8p9d/d2Y3M+ykKcwaMDEL+4qyUolgBDX6AblpR3fL212Q==",
       "requires": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -7128,30 +11205,21 @@
       },
       "dependencies": {
         "cookie": {
-          "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-          "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw=="
+          "version": "0.5.0"
         },
         "debug": {
           "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "requires": {
             "ms": "2.0.0"
           }
         },
         "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+          "version": "2.0.0"
         }
       }
     },
     "fast-deep-equal": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "version": "3.1.3"
     },
     "fast-diff": {
       "version": "1.2.0",
@@ -7161,8 +11229,6 @@
     },
     "fast-glob": {
       "version": "3.2.11",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
-      "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
       "dev": true,
       "requires": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -7170,38 +11236,59 @@
         "glob-parent": "^5.1.2",
         "merge2": "^1.3.0",
         "micromatch": "^4.0.4"
+      },
+      "dependencies": {
+        "glob-parent": {
+          "version": "5.1.2",
+          "dev": true,
+          "requires": {
+            "is-glob": "^4.0.1"
+          }
+        }
       }
     },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "dev": true
     },
     "fast-levenshtein": {
       "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
     },
     "fastq": {
       "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
-      "integrity": "sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==",
       "dev": true,
       "requires": {
         "reusify": "^1.0.4"
       }
     },
+    "fecha": {
+      "version": "4.2.3"
+    },
     "fetch-blob": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-2.1.2.tgz",
-      "integrity": "sha512-YKqtUDwqLyfyMnmbw8XD6Q8j9i/HggKtPEI+pZ1+8bvheBu78biSmNaXWusx1TauGqtUUGx/cBb1mKdq2rLYow=="
+      "version": "2.1.2"
+    },
+    "fetch-sparql-endpoint": {
+      "version": "2.4.1",
+      "requires": {
+        "@rdfjs/types": "*",
+        "@types/readable-stream": "^2.3.11",
+        "@types/sparqljs": "^3.1.3",
+        "abort-controller": "^3.0.0",
+        "cross-fetch": "^3.0.6",
+        "is-stream": "^2.0.0",
+        "minimist": "^1.2.0",
+        "n3": "^1.6.3",
+        "rdf-string": "^1.6.0",
+        "readable-web-to-node-stream": "^3.0.2",
+        "sparqljs": "^3.1.2",
+        "sparqljson-parse": "^1.7.0",
+        "sparqlxml-parse": "^1.5.0",
+        "stream-to-string": "^1.1.0"
+      }
     },
     "file-entry-cache": {
       "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
-      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
       "dev": true,
       "requires": {
         "flat-cache": "^3.0.4"
@@ -7209,8 +11296,6 @@
     },
     "fill-range": {
       "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
       "devOptional": true,
       "requires": {
         "to-regex-range": "^5.0.1"
@@ -7218,8 +11303,6 @@
     },
     "finalhandler": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.0.tgz",
-      "integrity": "sha512-5uXcUVftlQMFnWC9qu/svkWv3GTd2PfUhK/3PLkYNAe7FbqJMt3515HaxE6eRL74GdsriiwujiawdaB1BpEISg==",
       "requires": {
         "debug": "2.6.9",
         "encodeurl": "~1.0.2",
@@ -7232,23 +11315,17 @@
       "dependencies": {
         "debug": {
           "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "requires": {
             "ms": "2.0.0"
           }
         },
         "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+          "version": "2.0.0"
         }
       }
     },
     "find-up": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
       "dev": true,
       "requires": {
         "locate-path": "^6.0.0",
@@ -7257,14 +11334,10 @@
     },
     "flat": {
       "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
-      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
       "dev": true
     },
     "flat-cache": {
       "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
-      "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
       "dev": true,
       "requires": {
         "flatted": "^3.1.0",
@@ -7273,37 +11346,23 @@
     },
     "flatted": {
       "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.6.tgz",
-      "integrity": "sha512-0sQoMh9s0BYsm+12Huy/rkKxVu4R1+r96YX5cG44rHV0pQ6iC3Q+mkoMFaGWObMFYQxCVT+ssG1ksneA2MI9KQ==",
       "dev": true
     },
+    "fn.name": {
+      "version": "1.1.0"
+    },
     "forwarded": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
-      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="
+      "version": "0.2.0"
     },
     "fresh": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q=="
+      "version": "0.5.2"
     },
     "fs.realpath": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true
     },
-    "fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "optional": true
-    },
     "function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+      "version": "1.1.1"
     },
     "function.prototype.name": {
       "version": "1.1.5",
@@ -7319,8 +11378,6 @@
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-      "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
       "dev": true
     },
     "functions-have-names": {
@@ -7330,21 +11387,14 @@
       "dev": true
     },
     "get-caller-file": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true
+      "version": "2.0.5"
     },
     "get-func-name": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
-      "integrity": "sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==",
       "dev": true
     },
     "get-intrinsic": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.2.tgz",
-      "integrity": "sha512-Jfm3OyCxHh9DJyc28qGk+JmfkpO41A4XkneDSujN9MDXrm4oDKdHvndhZ2dN94+ERNfkYJWDclW6k2L/ZGHjXA==",
       "requires": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
@@ -7363,8 +11413,6 @@
     },
     "glob": {
       "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
-      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
       "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
@@ -7376,18 +11424,14 @@
       }
     },
     "glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "devOptional": true,
+      "version": "6.0.2",
+      "dev": true,
       "requires": {
-        "is-glob": "^4.0.1"
+        "is-glob": "^4.0.3"
       }
     },
     "globals": {
-      "version": "13.15.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.15.0.tgz",
-      "integrity": "sha512-bpzcOlgDhMG070Av0Vy5Owklpv1I6+j96GhUI7Rh7IzDCKLzboflLrrfqMu8NquDbiR4EOQk7XzJwqVJxicxog==",
+      "version": "13.17.0",
       "dev": true,
       "requires": {
         "type-fest": "^0.20.2"
@@ -7395,8 +11439,6 @@
     },
     "globby": {
       "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
-      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
       "dev": true,
       "requires": {
         "array-union": "^2.1.0",
@@ -7414,14 +11456,24 @@
     },
     "grapheme-splitter": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
-      "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
       "dev": true
+    },
+    "graphql": {
+      "version": "15.8.0"
+    },
+    "graphql-to-sparql": {
+      "version": "3.0.0",
+      "requires": {
+        "@rdfjs/types": "*",
+        "graphql": "^15.5.2",
+        "jsonld-context-parser": "^2.0.2",
+        "minimist": "^1.2.0",
+        "rdf-data-factory": "^1.1.0",
+        "sparqlalgebrajs": "^4.0.0"
+      }
     },
     "has": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
       "requires": {
         "function-bind": "^1.1.1"
       }
@@ -7433,10 +11485,7 @@
       "dev": true
     },
     "has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true
+      "version": "4.0.0"
     },
     "has-property-descriptors": {
       "version": "1.0.0",
@@ -7448,9 +11497,7 @@
       }
     },
     "has-symbols": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A=="
+      "version": "1.0.3"
     },
     "has-tostringtag": {
       "version": "1.0.0",
@@ -7461,16 +11508,28 @@
         "has-symbols": "^1.0.2"
       }
     },
+    "hash.js": {
+      "version": "1.1.7",
+      "requires": {
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.1"
+      }
+    },
     "he": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
-      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true
+    },
+    "htmlparser2": {
+      "version": "7.2.0",
+      "requires": {
+        "domelementtype": "^2.0.1",
+        "domhandler": "^4.2.2",
+        "domutils": "^2.8.0",
+        "entities": "^3.0.1"
+      }
     },
     "http-errors": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
-      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
       "requires": {
         "depd": "2.0.0",
         "inherits": "2.0.4",
@@ -7480,9 +11539,7 @@
       }
     },
     "http-link-header": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/http-link-header/-/http-link-header-1.0.5.tgz",
-      "integrity": "sha512-msKrMbv/xHzhdOD4sstbEr+NbGqpv8ZtZliiCeByGENJo1jK1GZ/81zHF9HpWtEH5ihovPpdqHXniwZapJCKEA=="
+      "version": "1.0.5"
     },
     "i18next": {
       "version": "21.9.0",
@@ -7498,40 +11555,27 @@
       "integrity": "sha512-raTel3EfshiUXxR0gvmIoqp75jhkj8+7R1LjB006VZKPTFBbXyx6TlUVhb8Z9+7ahgpFbcQg1QWVOdf/iNzI5A=="
     },
     "i18next-http-middleware": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/i18next-http-middleware/-/i18next-http-middleware-3.2.1.tgz",
-      "integrity": "sha512-zBwXxDChT0YLoTXIR6jRuqnUUhXW0Iw7egoTnNXyaDRtTbfWNXwU0a53ThyuRPQ+k+tXu3ZMNKRzfLuononaRw=="
+      "version": "3.2.1"
     },
     "iconv-lite": {
       "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
     },
     "ignore": {
       "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
-      "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
       "dev": true
     },
     "ignore-by-default": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
-      "integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==",
       "dev": true
     },
     "immutable": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.1.0.tgz",
-      "integrity": "sha512-oNkuqVTA8jqG1Q6c+UglTOD1xhC1BtjKI7XkCXRkZHrN5m18/XsnUp8Q89GkQO/z+0WjonSvl0FLhDYftp46nQ==",
-      "dev": true
+      "version": "4.1.0"
     },
     "import-fresh": {
       "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
-      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
       "dev": true,
       "requires": {
         "parent-module": "^1.0.0",
@@ -7540,14 +11584,10 @@
     },
     "imurmurhash": {
       "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
       "dev": true
     },
     "inflight": {
       "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "dev": true,
       "requires": {
         "once": "^1.3.0",
@@ -7555,9 +11595,7 @@
       }
     },
     "inherits": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+      "version": "2.0.4"
     },
     "internal-slot": {
       "version": "1.0.3",
@@ -7571,9 +11609,10 @@
       }
     },
     "ipaddr.js": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
-      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
+      "version": "1.9.1"
+    },
+    "is-arrayish": {
+      "version": "0.3.2"
     },
     "is-bigint": {
       "version": "1.0.4",
@@ -7586,8 +11625,6 @@
     },
     "is-binary-path": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
-      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
       "devOptional": true,
       "requires": {
         "binary-extensions": "^2.0.0"
@@ -7610,9 +11647,9 @@
       "dev": true
     },
     "is-core-module": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
-      "integrity": "sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.10.0.tgz",
+      "integrity": "sha512-Erxj2n/LDAZ7H8WNJXd9tw38GYM3dv8rk8Zcs+jJuxYTW7sozH+SS8NtrSjVL1/vpLvWi1hxy96IzjJ3EHTJJg==",
       "dev": true,
       "requires": {
         "has": "^1.0.3"
@@ -7627,22 +11664,18 @@
         "has-tostringtag": "^1.0.0"
       }
     },
+    "is-docker": {
+      "version": "2.2.1"
+    },
     "is-extglob": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
       "devOptional": true
     },
     "is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true
+      "version": "3.0.0"
     },
     "is-glob": {
       "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
-      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
       "devOptional": true,
       "requires": {
         "is-extglob": "^2.1.1"
@@ -7656,8 +11689,6 @@
     },
     "is-number": {
       "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "devOptional": true
     },
     "is-number-object": {
@@ -7671,8 +11702,6 @@
     },
     "is-plain-obj": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
-      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
       "dev": true
     },
     "is-regex": {
@@ -7694,6 +11723,9 @@
         "call-bind": "^1.0.2"
       }
     },
+    "is-stream": {
+      "version": "2.0.1"
+    },
     "is-string": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
@@ -7714,8 +11746,6 @@
     },
     "is-unicode-supported": {
       "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
-      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
       "dev": true
     },
     "is-weakref": {
@@ -7727,22 +11757,43 @@
         "call-bind": "^1.0.2"
       }
     },
+    "is-wsl": {
+      "version": "2.2.0",
+      "requires": {
+        "is-docker": "^2.0.0"
+      }
+    },
     "isarray": {
       "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
       "dev": true
     },
     "isexe": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
     },
+    "jest-diff": {
+      "version": "27.5.1",
+      "requires": {
+        "chalk": "^4.0.0",
+        "diff-sequences": "^27.5.1",
+        "jest-get-type": "^27.5.1",
+        "pretty-format": "^27.5.1"
+      }
+    },
+    "jest-get-type": {
+      "version": "27.5.1"
+    },
+    "jest-matcher-utils": {
+      "version": "27.5.1",
+      "requires": {
+        "chalk": "^4.0.0",
+        "jest-diff": "^27.5.1",
+        "jest-get-type": "^27.5.1",
+        "pretty-format": "^27.5.1"
+      }
+    },
     "jose": {
-      "version": "4.8.3",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-4.8.3.tgz",
-      "integrity": "sha512-7rySkpW78d8LBp4YU70Wb7+OTgE3OwAALNVZxhoIhp4Kscp+p/fBkdpxGAMKxvCAMV4QfXBU9m6l9nX/vGwd2g=="
+      "version": "4.8.3"
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -7752,8 +11803,6 @@
     },
     "js-yaml": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
       "dev": true,
       "requires": {
         "argparse": "^2.0.1"
@@ -7761,14 +11810,10 @@
     },
     "json-schema-traverse": {
       "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true
     },
     "json5": {
@@ -7782,13 +11827,51 @@
     },
     "jsonld": {
       "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/jsonld/-/jsonld-5.2.0.tgz",
-      "integrity": "sha512-JymgT6Xzk5CHEmHuEyvoTNviEPxv6ihLWSPu1gFdtjSAyM6cFqNrv02yS/SIur3BBIkCf0HjizRc24d8/FfQKw==",
       "requires": {
         "@digitalbazaar/http-client": "^1.1.0",
         "canonicalize": "^1.0.1",
         "lru-cache": "^6.0.0",
         "rdf-canonize": "^3.0.0"
+      }
+    },
+    "jsonld-context-parser": {
+      "version": "2.2.0",
+      "requires": {
+        "@types/http-link-header": "^1.0.1",
+        "@types/node": "^18.0.0",
+        "canonicalize": "^1.0.1",
+        "cross-fetch": "^3.0.6",
+        "http-link-header": "^1.0.2",
+        "relative-to-absolute-iri": "^1.0.5"
+      }
+    },
+    "jsonld-streaming-parser": {
+      "version": "2.4.3",
+      "requires": {
+        "@rdfjs/types": "*",
+        "@types/http-link-header": "^1.0.1",
+        "canonicalize": "^1.0.1",
+        "http-link-header": "^1.0.2",
+        "jsonld-context-parser": "^2.1.3",
+        "jsonparse": "^1.3.1",
+        "rdf-data-factory": "^1.1.0"
+      }
+    },
+    "jsonld-streaming-serializer": {
+      "version": "1.3.0",
+      "requires": {
+        "@rdfjs/types": "*",
+        "jsonld-context-parser": "^2.0.0"
+      }
+    },
+    "jsonparse": {
+      "version": "1.3.1"
+    },
+    "JSONStream": {
+      "version": "1.3.5",
+      "requires": {
+        "jsonparse": "^1.2.0",
+        "through": ">=2.2.7 <3"
       }
     },
     "jsonwebtoken": {
@@ -7816,19 +11899,17 @@
       }
     },
     "jsx-ast-utils": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.2.tgz",
-      "integrity": "sha512-4ZCADZHRkno244xlNnn4AOG6sRQ7iBZ5BbgZ4vW4y5IZw7cVUD1PPeblm1xx/nfmMxPdt/LHsXZW8z/j58+l9Q==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.3.tgz",
+      "integrity": "sha512-fYQHZTZ8jSfmWZ0iyzfwiU4WDX4HpHbMCZ3gPlWYiCl3BoeOTsqKBqnTVfH2rYT7eP5c3sVbeSPHnnJOaTrWiw==",
       "dev": true,
       "requires": {
         "array-includes": "^3.1.5",
-        "object.assign": "^4.1.2"
+        "object.assign": "^4.1.3"
       }
     },
     "just-extend": {
       "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
-      "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
       "dev": true
     },
     "jwa": {
@@ -7852,21 +11933,18 @@
     },
     "keygrip": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/keygrip/-/keygrip-1.1.0.tgz",
-      "integrity": "sha512-iYSchDJ+liQ8iwbSI2QqsQOvqv58eJCEanyJPJi+Khyu8smkcKSFUCbPwzFcL7YVtZ6eONjqRX/38caJ7QjRAQ==",
       "requires": {
         "tsscmp": "1.0.6"
       }
     },
+    "kuler": {
+      "version": "2.0.0"
+    },
     "ky": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/ky/-/ky-0.25.1.tgz",
-      "integrity": "sha512-PjpCEWlIU7VpiMVrTwssahkYXX1by6NCT0fhTUX34F3DTinARlgMpriuroolugFPcMgpPWrOW4mTb984Qm1RXA=="
+      "version": "0.25.1"
     },
     "ky-universal": {
       "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/ky-universal/-/ky-universal-0.8.2.tgz",
-      "integrity": "sha512-xe0JaOH9QeYxdyGLnzUOVGK4Z6FGvDVzcXFTdrYA1f33MZdEa45sUDaMBy98xQMcsd2XIBrTXRrRYnegcSdgVQ==",
       "requires": {
         "abort-controller": "^3.0.0",
         "node-fetch": "3.0.0-beta.9"
@@ -7874,8 +11952,6 @@
       "dependencies": {
         "node-fetch": {
           "version": "3.0.0-beta.9",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.0.0-beta.9.tgz",
-          "integrity": "sha512-RdbZCEynH2tH46+tj0ua9caUHVWrd/RHnRfvly2EVdqGmI3ndS1Vn/xjm5KuGejDt2RNDQsVRLPNd2QPwcewVg==",
           "requires": {
             "data-uri-to-buffer": "^3.0.1",
             "fetch-blob": "^2.1.1"
@@ -7900,8 +11976,6 @@
     },
     "levn": {
       "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
-      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
       "dev": true,
       "requires": {
         "prelude-ls": "^1.2.1",
@@ -7910,22 +11984,16 @@
     },
     "locate-path": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
       "dev": true,
       "requires": {
         "p-locate": "^5.0.0"
       }
     },
     "lodash.clonedeep": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ=="
+      "version": "4.5.0"
     },
     "lodash.get": {
       "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
       "dev": true
     },
     "lodash.includes": {
@@ -7960,8 +12028,6 @@
     },
     "lodash.merge": {
       "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
     },
     "lodash.once": {
@@ -7971,12 +12037,20 @@
     },
     "log-symbols": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
-      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
       "dev": true,
       "requires": {
         "chalk": "^4.1.0",
         "is-unicode-supported": "^0.1.0"
+      }
+    },
+    "logform": {
+      "version": "2.4.2",
+      "requires": {
+        "@colors/colors": "1.5.0",
+        "fecha": "^4.2.0",
+        "ms": "^2.1.1",
+        "safe-stable-stringify": "^2.3.1",
+        "triple-beam": "^1.3.0"
       }
     },
     "loose-envify": {
@@ -7990,8 +12064,6 @@
     },
     "loupe": {
       "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.4.tgz",
-      "integrity": "sha512-OvKfgCC2Ndby6aSTREl5aCCPTNIzlDfQZvZxNUrBrihDhL3xcrYegTblhmEiCrg2kKQz4XsFIaemE5BF4ybSaQ==",
       "dev": true,
       "requires": {
         "get-func-name": "^2.0.0"
@@ -7999,43 +12071,52 @@
     },
     "lru-cache": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
       "requires": {
         "yallist": "^4.0.0"
       }
     },
     "make-error": {
       "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
       "dev": true
     },
     "media-typer": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ=="
+      "version": "0.3.0"
     },
     "merge-descriptors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-      "integrity": "sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w=="
+      "version": "1.0.1"
     },
     "merge2": {
       "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
       "dev": true
     },
     "methods": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w=="
+      "version": "1.1.2"
+    },
+    "microdata-rdf-streaming-parser": {
+      "version": "1.2.0",
+      "requires": {
+        "@rdfjs/types": "*",
+        "htmlparser2": "^6.0.0",
+        "rdf-data-factory": "^1.1.0",
+        "relative-to-absolute-iri": "^1.0.2"
+      },
+      "dependencies": {
+        "entities": {
+          "version": "2.2.0"
+        },
+        "htmlparser2": {
+          "version": "6.1.0",
+          "requires": {
+            "domelementtype": "^2.0.1",
+            "domhandler": "^4.0.0",
+            "domutils": "^2.5.2",
+            "entities": "^2.0.0"
+          }
+        }
+      }
     },
     "micromatch": {
       "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
       "dev": true,
       "requires": {
         "braces": "^3.0.2",
@@ -8043,42 +12124,32 @@
       }
     },
     "mime": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
+      "version": "1.6.0"
     },
     "mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
+      "version": "1.52.0"
     },
     "mime-types": {
       "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
       "requires": {
         "mime-db": "1.52.0"
       }
     },
+    "minimalistic-assert": {
+      "version": "1.0.1"
+    },
     "minimatch": {
       "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
-      "dev": true
+      "version": "1.2.6"
     },
     "mocha": {
       "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.0.0.tgz",
-      "integrity": "sha512-0Wl+elVUD43Y0BqPZBzZt8Tnkw9CMUdNYnUsTfOM1vuhJVZL+kiesFYsqwBkEEuEixaiPe5ZQdqDgX2jddhmoA==",
       "dev": true,
       "requires": {
         "@ungap/promise-all-settled": "1.1.2",
@@ -8107,8 +12178,6 @@
       "dependencies": {
         "brace-expansion": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
           "dev": true,
           "requires": {
             "balanced-match": "^1.0.0"
@@ -8116,28 +12185,46 @@
         },
         "minimatch": {
           "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
-          "integrity": "sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==",
           "dev": true,
           "requires": {
             "brace-expansion": "^2.0.1"
           }
         },
+        "ms": {
+          "version": "2.1.3",
+          "dev": true
+        },
+        "serialize-javascript": {
+          "version": "6.0.0",
+          "dev": true,
+          "requires": {
+            "randombytes": "^2.1.0"
+          }
+        },
         "supports-color": {
           "version": "8.1.1",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-          "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
           "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
+          }
+        },
+        "yargs": {
+          "version": "16.2.0",
+          "dev": true,
+          "requires": {
+            "cliui": "^7.0.2",
+            "escalade": "^3.1.1",
+            "get-caller-file": "^2.0.5",
+            "require-directory": "^2.1.1",
+            "string-width": "^4.2.0",
+            "y18n": "^5.0.5",
+            "yargs-parser": "^20.2.2"
           }
         }
       }
     },
     "morgan": {
       "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.0.tgz",
-      "integrity": "sha512-AbegBVI4sh6El+1gNwvD5YIck7nSA36weD7xvIxG4in80j/UoK8AEGaWnnz8v1GxonMCltmlNs5ZKbGvl9b1XQ==",
       "requires": {
         "basic-auth": "~2.0.1",
         "debug": "2.6.9",
@@ -8148,21 +12235,15 @@
       "dependencies": {
         "debug": {
           "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "requires": {
             "ms": "2.0.0"
           }
         },
         "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+          "version": "2.0.0"
         },
         "on-finished": {
           "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-          "integrity": "sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==",
           "requires": {
             "ee-first": "1.1.1"
           }
@@ -8170,14 +12251,10 @@
       }
     },
     "ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+      "version": "2.1.2"
     },
     "n3": {
       "version": "1.16.2",
-      "resolved": "https://registry.npmjs.org/n3/-/n3-1.16.2.tgz",
-      "integrity": "sha512-5vYa2HuNEJ+a26FEs4FGgfFLgaPOODaZpJlc7FS0eUjDumc4uK0cvx216PjKXBkLzmAsSqGgQPwqztcLLvwDsw==",
       "requires": {
         "queue-microtask": "^1.1.2",
         "readable-stream": "^3.6.0"
@@ -8185,25 +12262,20 @@
     },
     "nanoid": {
       "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.3.tgz",
-      "integrity": "sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==",
       "dev": true
     },
     "natural-compare": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
     },
+    "negotiate": {
+      "version": "1.0.1"
+    },
     "negotiator": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
-      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="
+      "version": "0.6.3"
     },
     "nise": {
       "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.1.tgz",
-      "integrity": "sha512-yr5kW2THW1AkxVmCnKEh4nbYkJdB3I7LUkiUgOvEkOp414mc2UMaHMA7pjq1nYowhdoJZGwEKGaQVbxfpWj10A==",
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.8.3",
@@ -8215,8 +12287,6 @@
       "dependencies": {
         "path-to-regexp": {
           "version": "1.8.0",
-          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
-          "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
           "dev": true,
           "requires": {
             "isarray": "0.0.1"
@@ -8226,16 +12296,12 @@
     },
     "node-fetch": {
       "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
       "requires": {
         "whatwg-url": "^5.0.0"
       }
     },
     "nodemon": {
       "version": "2.0.19",
-      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-2.0.19.tgz",
-      "integrity": "sha512-4pv1f2bMDj0Eeg/MhGqxrtveeQ5/G/UVe9iO6uTZzjnRluSA4PVWf8CW99LUPwGB3eNIA7zUFoP77YuI7hOc0A==",
       "dev": true,
       "requires": {
         "chokidar": "^3.5.2",
@@ -8252,8 +12318,6 @@
       "dependencies": {
         "debug": {
           "version": "3.2.7",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
           "dev": true,
           "requires": {
             "ms": "^2.1.1"
@@ -8261,20 +12325,14 @@
         },
         "has-flag": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
           "dev": true
         },
         "semver": {
           "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
           "dev": true
         },
         "supports-color": {
           "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
           "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
@@ -8284,8 +12342,6 @@
     },
     "nopt": {
       "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
-      "integrity": "sha512-NWmpvLSqUrgrAC9HCuxEvb+PSloHpqVu+FqcO4eeF2h5qYRhA7ev6KvelyQAKtegUbC6RypJnlEOhd8vloNKYg==",
       "dev": true,
       "requires": {
         "abbrev": "1"
@@ -8293,14 +12349,10 @@
     },
     "normalize-path": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "devOptional": true
     },
     "nunjucks": {
       "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/nunjucks/-/nunjucks-3.2.3.tgz",
-      "integrity": "sha512-psb6xjLj47+fE76JdZwskvwG4MYsQKXUtMsPh6U0YMvmyjRtKRFcxnlXGWglNybtNTNVmGdp94K62/+NjF5FDQ==",
       "requires": {
         "a-sync-waterfall": "^1.0.0",
         "asap": "^2.0.3",
@@ -8314,14 +12366,10 @@
       "dev": true
     },
     "object-hash": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
-      "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw=="
+      "version": "2.2.0"
     },
     "object-inspect": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
-      "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ=="
+      "version": "1.12.2"
     },
     "object-keys": {
       "version": "1.1.1",
@@ -8330,14 +12378,14 @@
       "dev": true
     },
     "object.assign": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
-      "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.3.tgz",
+      "integrity": "sha512-ZFJnX3zltyjcYJL0RoCJuzb+11zWGyaDbjgxZbdV7rFEcHQuYxrZqhow67aA7xpes6LhojyFDaBKAFfogQrikA==",
       "dev": true,
       "requires": {
-        "call-bind": "^1.0.0",
-        "define-properties": "^1.1.3",
-        "has-symbols": "^1.0.1",
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "has-symbols": "^1.0.3",
         "object-keys": "^1.1.1"
       }
     },
@@ -8385,36 +12433,40 @@
       }
     },
     "oidc-token-hash": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/oidc-token-hash/-/oidc-token-hash-5.0.1.tgz",
-      "integrity": "sha512-EvoOtz6FIEBzE+9q253HsLCVRiK/0doEJ2HCvvqMQb3dHZrP3WlJKYtJ55CRTw4jmYomzH4wkPuCj/I3ZvpKxQ=="
+      "version": "5.0.1"
     },
     "on-finished": {
       "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
-      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
       "requires": {
         "ee-first": "1.1.1"
       }
     },
     "on-headers": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
-      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA=="
+      "version": "1.0.2"
     },
     "once": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "dev": true,
       "requires": {
         "wrappy": "1"
       }
     },
+    "one-time": {
+      "version": "1.0.0",
+      "requires": {
+        "fn.name": "1.x.x"
+      }
+    },
+    "open": {
+      "version": "8.4.0",
+      "requires": {
+        "define-lazy-prop": "^2.0.0",
+        "is-docker": "^2.1.1",
+        "is-wsl": "^2.2.0"
+      }
+    },
     "openid-client": {
-      "version": "5.1.7",
-      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-5.1.7.tgz",
-      "integrity": "sha512-VNtf/q+fv2Jiqi0ViLVmN3gGMSHF+YUGW6baKA/naoPKkKw4JdvghaP/kXQ/bzRRDWk6VmpCYDcR934UdDs8ug==",
+      "version": "5.1.8",
       "requires": {
         "jose": "^4.1.4",
         "lru-cache": "^6.0.0",
@@ -8424,8 +12476,6 @@
     },
     "optionator": {
       "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
-      "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
       "dev": true,
       "requires": {
         "deep-is": "^0.1.3",
@@ -8438,8 +12488,6 @@
     },
     "p-limit": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
       "dev": true,
       "requires": {
         "yocto-queue": "^0.1.0"
@@ -8447,8 +12495,6 @@
     },
     "p-locate": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
       "dev": true,
       "requires": {
         "p-limit": "^3.0.2"
@@ -8462,34 +12508,24 @@
     },
     "parent-module": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
-      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
       "dev": true,
       "requires": {
         "callsites": "^3.0.0"
       }
     },
     "parseurl": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
-      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
+      "version": "1.3.3"
     },
     "path-exists": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
       "dev": true
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
       "dev": true
     },
     "path-key": {
       "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "dev": true
     },
     "path-parse": {
@@ -8499,32 +12535,22 @@
       "dev": true
     },
     "path-to-regexp": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-      "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ=="
+      "version": "0.1.7"
     },
     "path-type": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
       "dev": true
     },
     "pathval": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
-      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
       "dev": true
     },
     "picomatch": {
       "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "devOptional": true
     },
     "prelude-ls": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
-      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "dev": true
     },
     "prettier": {
@@ -8543,6 +12569,22 @@
         "fast-diff": "^1.1.2"
       }
     },
+    "pretty-format": {
+      "version": "27.5.1",
+      "requires": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "5.2.0"
+        }
+      }
+    },
+    "promise-polyfill": {
+      "version": "1.1.6"
+    },
     "prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -8552,12 +12594,18 @@
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
         "react-is": "^16.13.1"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+          "dev": true
+        }
       }
     },
     "proxy-addr": {
       "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
-      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
       "requires": {
         "forwarded": "0.2.0",
         "ipaddr.js": "1.9.1"
@@ -8565,47 +12613,32 @@
     },
     "pstree.remy": {
       "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
-      "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==",
       "dev": true
     },
     "punycode": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true
     },
     "qs": {
       "version": "6.10.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz",
-      "integrity": "sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==",
       "requires": {
         "side-channel": "^1.0.4"
       }
     },
     "queue-microtask": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="
+      "version": "1.2.3"
     },
     "randombytes": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dev": true,
       "requires": {
         "safe-buffer": "^5.1.0"
       }
     },
     "range-parser": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
-      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
+      "version": "1.2.1"
     },
     "raw-body": {
       "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
-      "integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
       "requires": {
         "bytes": "3.1.2",
         "http-errors": "2.0.0",
@@ -8615,49 +12648,173 @@
     },
     "rdf-canonize": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/rdf-canonize/-/rdf-canonize-3.0.0.tgz",
-      "integrity": "sha512-LXRkhab1QaPJnhUIt1gtXXKswQCZ9zpflsSZFczG7mCLAkMvVjdqCGk9VXCUss0aOUeEyV2jtFxGcdX8DSkj9w==",
       "requires": {
         "setimmediate": "^1.0.5"
       }
     },
-    "rdf-js": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/rdf-js/-/rdf-js-4.0.2.tgz",
-      "integrity": "sha512-ApvlFa/WsQh8LpPK/6hctQwG06Z9ztQQGWVtrcrf9L6+sejHNXLPOqL+w7q3hF+iL0C4sv3AX1PUtGkLNzyZ0Q==",
+    "rdf-data-factory": {
+      "version": "1.1.1",
       "requires": {
         "@rdfjs/types": "*"
       }
     },
+    "rdf-isomorphic": {
+      "version": "1.3.0",
+      "requires": {
+        "@rdfjs/types": "*",
+        "hash.js": "^1.1.7",
+        "rdf-string": "^1.6.0",
+        "rdf-terms": "^1.7.0"
+      }
+    },
+    "rdf-js": {
+      "version": "4.0.2",
+      "requires": {
+        "@rdfjs/types": "*"
+      }
+    },
+    "rdf-literal": {
+      "version": "1.3.0",
+      "requires": {
+        "@rdfjs/types": "*",
+        "rdf-data-factory": "^1.1.0"
+      }
+    },
+    "rdf-object": {
+      "version": "1.13.1",
+      "requires": {
+        "@rdfjs/types": "*",
+        "jsonld-context-parser": "^2.0.2",
+        "rdf-data-factory": "^1.1.0",
+        "rdf-string": "^1.6.0",
+        "streamify-array": "^1.0.1"
+      }
+    },
+    "rdf-parse": {
+      "version": "2.1.0",
+      "requires": {
+        "@comunica/actor-http-fetch": "^2.0.1",
+        "@comunica/actor-http-proxy": "^2.0.1",
+        "@comunica/actor-rdf-parse-html": "^2.0.1",
+        "@comunica/actor-rdf-parse-html-microdata": "^2.0.1",
+        "@comunica/actor-rdf-parse-html-rdfa": "^2.0.1",
+        "@comunica/actor-rdf-parse-html-script": "^2.0.1",
+        "@comunica/actor-rdf-parse-jsonld": "^2.0.1",
+        "@comunica/actor-rdf-parse-n3": "^2.0.1",
+        "@comunica/actor-rdf-parse-rdfxml": "^2.0.1",
+        "@comunica/actor-rdf-parse-xml-rdfa": "^2.0.1",
+        "@comunica/bus-http": "^2.0.1",
+        "@comunica/bus-init": "^2.0.1",
+        "@comunica/bus-rdf-parse": "^2.0.1",
+        "@comunica/bus-rdf-parse-html": "^2.0.1",
+        "@comunica/config-query-sparql": "^2.0.1",
+        "@comunica/core": "^2.0.1",
+        "@comunica/mediator-combine-pipeline": "^2.0.1",
+        "@comunica/mediator-combine-union": "^2.0.1",
+        "@comunica/mediator-number": "^2.0.1",
+        "@comunica/mediator-race": "^2.0.1",
+        "@rdfjs/types": "*",
+        "stream-to-string": "^1.2.0"
+      }
+    },
+    "rdf-quad": {
+      "version": "1.5.0",
+      "requires": {
+        "rdf-data-factory": "^1.0.1",
+        "rdf-literal": "^1.2.0",
+        "rdf-string": "^1.5.0"
+      }
+    },
+    "rdf-store-stream": {
+      "version": "1.3.0",
+      "requires": {
+        "@rdfjs/types": "*",
+        "n3": "^1.11.1"
+      }
+    },
+    "rdf-string": {
+      "version": "1.6.1",
+      "requires": {
+        "@rdfjs/types": "*",
+        "rdf-data-factory": "^1.1.0"
+      }
+    },
+    "rdf-string-ttl": {
+      "version": "1.2.0",
+      "requires": {
+        "@rdfjs/types": "*",
+        "rdf-data-factory": "^1.1.0"
+      }
+    },
+    "rdf-terms": {
+      "version": "1.9.0",
+      "requires": {
+        "@rdfjs/types": "*",
+        "rdf-data-factory": "^1.1.0",
+        "rdf-string": "^1.6.0"
+      }
+    },
+    "rdfa-streaming-parser": {
+      "version": "1.5.0",
+      "requires": {
+        "@rdfjs/types": "*",
+        "htmlparser2": "^6.0.0",
+        "rdf-data-factory": "^1.1.0",
+        "relative-to-absolute-iri": "^1.0.2"
+      },
+      "dependencies": {
+        "entities": {
+          "version": "2.2.0"
+        },
+        "htmlparser2": {
+          "version": "6.1.0",
+          "requires": {
+            "domelementtype": "^2.0.1",
+            "domhandler": "^4.0.0",
+            "domutils": "^2.5.2",
+            "entities": "^2.0.0"
+          }
+        }
+      }
+    },
+    "rdfxml-streaming-parser": {
+      "version": "1.5.0",
+      "requires": {
+        "@rdfjs/types": "*",
+        "rdf-data-factory": "^1.1.0",
+        "relative-to-absolute-iri": "^1.0.0",
+        "sax": "^1.2.4"
+      }
+    },
     "react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true
+      "version": "17.0.2"
     },
     "readable-stream": {
       "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
       "requires": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
         "util-deprecate": "^1.0.1"
       }
     },
+    "readable-stream-node-to-web": {
+      "version": "1.0.1"
+    },
+    "readable-web-to-node-stream": {
+      "version": "3.0.2",
+      "requires": {
+        "readable-stream": "^3.6.0"
+      }
+    },
     "readdirp": {
       "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
       "devOptional": true,
       "requires": {
         "picomatch": "^2.2.1"
       }
     },
     "regenerator-runtime": {
-      "version": "0.13.9",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
+      "version": "0.13.9"
     },
     "regexp.prototype.flags": {
       "version": "1.4.3",
@@ -8672,15 +12829,13 @@
     },
     "regexpp": {
       "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
-      "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
       "dev": true
     },
+    "relative-to-absolute-iri": {
+      "version": "1.0.6"
+    },
     "require-directory": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-      "dev": true
+      "version": "2.1.1"
     },
     "resolve": {
       "version": "1.22.1",
@@ -8695,64 +12850,39 @@
     },
     "resolve-from": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "dev": true
     },
     "reusify": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
-      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
       "dev": true
     },
     "rimraf": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
       "dev": true,
       "requires": {
         "glob": "^7.1.3"
-      },
-      "dependencies": {
-        "glob": {
-          "version": "7.2.3",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-          "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.1.1",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        }
       }
     },
     "run-parallel": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
-      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
       "dev": true,
       "requires": {
         "queue-microtask": "^1.2.2"
       }
     },
     "safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+      "version": "5.2.1"
+    },
+    "safe-stable-stringify": {
+      "version": "2.3.1"
     },
     "safer-buffer": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+      "version": "2.1.2"
     },
     "sass": {
-      "version": "1.54.3",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.54.3.tgz",
-      "integrity": "sha512-fLodey5Qd41Pxp/Tk7Al97sViYwF/TazRc5t6E65O7JOk4XF8pzwIW7CvCxYVOfJFFI/1x5+elDyBIixrp+zrw==",
+      "version": "1.54.4",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.54.4.tgz",
+      "integrity": "sha512-3tmF16yvnBwtlPrNBHw/H907j8MlOX8aTBnlNX1yrKx24RKcJGPyLhFUwkoKBKesR3unP93/2z14Ll8NicwQUA==",
       "dev": true,
       "requires": {
         "chokidar": ">=3.0.0 <4.0.0",
@@ -8760,16 +12890,35 @@
         "source-map-js": ">=0.6.2 <2.0.0"
       }
     },
+    "sax": {
+      "version": "1.2.4"
+    },
+    "sax-stream": {
+      "version": "1.3.0",
+      "requires": {
+        "debug": "~2",
+        "sax": "~1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0"
+        }
+      }
+    },
     "semver": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
-      "integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==",
-      "dev": true
+      "version": "7.3.7",
+      "requires": {
+        "lru-cache": "^6.0.0"
+      }
     },
     "send": {
       "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.18.0.tgz",
-      "integrity": "sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==",
       "requires": {
         "debug": "2.6.9",
         "depd": "2.0.0",
@@ -8788,34 +12937,28 @@
       "dependencies": {
         "debug": {
           "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "requires": {
             "ms": "2.0.0"
           },
           "dependencies": {
             "ms": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-              "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+              "version": "2.0.0"
             }
           }
+        },
+        "ms": {
+          "version": "2.1.3"
         }
       }
     },
     "serialize-javascript": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
-      "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
-      "dev": true,
+      "version": "4.0.0",
       "requires": {
         "randombytes": "^2.1.0"
       }
     },
     "serve-static": {
       "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.15.0.tgz",
-      "integrity": "sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g==",
       "requires": {
         "encodeurl": "~1.0.2",
         "escape-html": "~1.0.3",
@@ -8824,19 +12967,13 @@
       }
     },
     "setimmediate": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
+      "version": "1.0.5"
     },
     "setprototypeof": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
-      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
+      "version": "1.2.0"
     },
     "shebang-command": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
       "dev": true,
       "requires": {
         "shebang-regex": "^3.0.0"
@@ -8844,33 +12981,37 @@
     },
     "shebang-regex": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true
     },
     "side-channel": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
-      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
       "requires": {
         "call-bind": "^1.0.0",
         "get-intrinsic": "^1.0.2",
         "object-inspect": "^1.9.0"
       }
     },
+    "simple-swizzle": {
+      "version": "0.2.2",
+      "requires": {
+        "is-arrayish": "^0.3.1"
+      }
+    },
     "simple-update-notifier": {
       "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-1.0.7.tgz",
-      "integrity": "sha512-BBKgR84BJQJm6WjWFMHgLVuo61FBDSj1z/xSFUIozqO6wO7ii0JxCqlIud7Enr/+LhlbNI0whErq96P2qHNWew==",
       "dev": true,
       "requires": {
         "semver": "~7.0.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "7.0.0",
+          "dev": true
+        }
       }
     },
     "sinon": {
       "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-14.0.0.tgz",
-      "integrity": "sha512-ugA6BFmE+WrJdh0owRZHToLd32Uw3Lxq6E6LtNRU+xTVBefx632h03Q7apXWRsRdZAJ41LB8aUfn2+O4jsDNMw==",
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.8.3",
@@ -8879,53 +13020,129 @@
         "diff": "^5.0.0",
         "nise": "^5.1.1",
         "supports-color": "^7.2.0"
-      },
-      "dependencies": {
-        "diff": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-5.1.0.tgz",
-          "integrity": "sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==",
-          "dev": true
-        }
       }
     },
     "sinon-chai": {
       "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-3.7.0.tgz",
-      "integrity": "sha512-mf5NURdUaSdnatJx3uhoBOrY9dtL19fiOtAdT1Azxg3+lNJFiuN0uzaU3xX1LeAfL17kHQhTAJgpsfhbMJMY2g==",
       "dev": true,
       "requires": {}
     },
     "slash": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "dev": true
+    },
+    "solid-node-interactive-auth": {
+      "version": "1.0.2",
+      "requires": {
+        "open": "^8.2.1"
+      }
     },
     "source-map-js": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
-      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
       "dev": true
     },
+    "spark-md5": {
+      "version": "3.0.2"
+    },
+    "sparqlalgebrajs": {
+      "version": "4.0.3",
+      "requires": {
+        "@rdfjs/types": "*",
+        "@types/sparqljs": "^3.1.3",
+        "fast-deep-equal": "^3.1.3",
+        "minimist": "^1.2.6",
+        "rdf-data-factory": "^1.1.0",
+        "rdf-isomorphic": "^1.3.0",
+        "rdf-string": "^1.6.0",
+        "sparqljs": "^3.5.2"
+      }
+    },
+    "sparqlee": {
+      "version": "2.1.0",
+      "requires": {
+        "@comunica/bindings-factory": "^2.0.1",
+        "@rdfjs/types": "*",
+        "@types/lru-cache": "^5.1.1",
+        "@types/spark-md5": "^3.0.2",
+        "@types/uuid": "^8.0.0",
+        "bignumber.js": "^9.0.1",
+        "hash.js": "^1.1.7",
+        "lru-cache": "^6.0.0",
+        "rdf-data-factory": "^1.1.0",
+        "rdf-string": "^1.6.0",
+        "relative-to-absolute-iri": "^1.0.6",
+        "spark-md5": "^3.0.1",
+        "sparqlalgebrajs": "^4.0.0",
+        "uuid": "^8.0.0"
+      }
+    },
+    "sparqljs": {
+      "version": "3.5.2",
+      "requires": {
+        "rdf-data-factory": "^1.0.4"
+      }
+    },
+    "sparqljson-parse": {
+      "version": "1.7.0",
+      "requires": {
+        "@rdfjs/types": "*",
+        "@types/node": "^13.1.0",
+        "JSONStream": "^1.3.3",
+        "rdf-data-factory": "^1.1.0"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "13.13.52"
+        }
+      }
+    },
+    "sparqljson-to-tree": {
+      "version": "2.1.0",
+      "requires": {
+        "rdf-literal": "^1.2.0",
+        "sparqljson-parse": "^1.6.0"
+      }
+    },
+    "sparqlxml-parse": {
+      "version": "1.5.0",
+      "requires": {
+        "@rdfjs/types": "*",
+        "@types/node": "^13.1.0",
+        "rdf-data-factory": "^1.1.0",
+        "sax-stream": "^1.2.3"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "13.13.52"
+        }
+      }
+    },
+    "stack-trace": {
+      "version": "0.0.10"
+    },
     "statuses": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ=="
+      "version": "2.0.1"
+    },
+    "stream-to-string": {
+      "version": "1.2.0",
+      "requires": {
+        "promise-polyfill": "^1.1.6"
+      }
+    },
+    "streamify-array": {
+      "version": "1.0.1"
+    },
+    "streamify-string": {
+      "version": "1.0.1"
     },
     "string_decoder": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
       "requires": {
         "safe-buffer": "~5.2.0"
       }
     },
     "string-width": {
       "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "requires": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -8972,9 +13189,6 @@
     },
     "strip-ansi": {
       "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "requires": {
         "ansi-regex": "^5.0.1"
       }
@@ -8987,15 +13201,10 @@
     },
     "strip-json-comments": {
       "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true
     },
     "supports-color": {
       "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
       "requires": {
         "has-flag": "^4.0.0"
       }
@@ -9006,44 +13215,41 @@
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
       "dev": true
     },
+    "text-hex": {
+      "version": "1.0.0"
+    },
     "text-table": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
+    },
+    "through": {
+      "version": "2.3.8"
     },
     "to-regex-range": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
       "devOptional": true,
       "requires": {
         "is-number": "^7.0.0"
       }
     },
     "toidentifier": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
-      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="
+      "version": "1.0.1"
     },
     "touch": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/touch/-/touch-3.1.0.tgz",
-      "integrity": "sha512-WBx8Uy5TLtOSRtIq+M03/sKDrXCLHxwDcquSP2c43Le03/9serjQBIztjRz6FkJez9D/hleyAXTBGLwwZUw9lA==",
       "dev": true,
       "requires": {
         "nopt": "~1.0.10"
       }
     },
     "tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+      "version": "0.0.3"
+    },
+    "triple-beam": {
+      "version": "1.3.0"
     },
     "ts-node": {
       "version": "10.9.1",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
-      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
       "dev": true,
       "requires": {
         "@cspotcode/source-map-support": "^0.8.0",
@@ -9061,10 +13267,12 @@
         "yn": "3.1.1"
       },
       "dependencies": {
+        "acorn": {
+          "version": "8.8.0",
+          "dev": true
+        },
         "diff": {
           "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-          "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
           "dev": true
         }
       }
@@ -9083,19 +13291,13 @@
     },
     "tslib": {
       "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "dev": true
     },
     "tsscmp": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
-      "integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA=="
+      "version": "1.0.6"
     },
     "tsutils": {
       "version": "3.21.0",
-      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
-      "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
       "dev": true,
       "requires": {
         "tslib": "^1.8.1"
@@ -9103,8 +13305,6 @@
     },
     "type-check": {
       "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
-      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
       "dev": true,
       "requires": {
         "prelude-ls": "^1.2.1"
@@ -9112,20 +13312,14 @@
     },
     "type-detect": {
       "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
       "dev": true
     },
     "type-fest": {
       "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
       "dev": true
     },
     "type-is": {
       "version": "1.6.18",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
-      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
       "requires": {
         "media-typer": "0.3.0",
         "mime-types": "~2.1.24"
@@ -9133,8 +13327,6 @@
     },
     "typescript": {
       "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
       "dev": true
     },
     "unbox-primitive": {
@@ -9151,65 +13343,62 @@
     },
     "undefsafe": {
       "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
-      "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
       "dev": true
     },
     "unpipe": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="
+      "version": "1.0.0"
     },
     "uri-js": {
       "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
-      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       }
     },
+    "uritemplate": {
+      "version": "0.3.4"
+    },
     "util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+      "version": "1.0.2"
     },
     "utils-merge": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA=="
+      "version": "1.0.1"
     },
     "uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+      "version": "8.3.2"
     },
     "v8-compile-cache": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
-      "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
       "dev": true
     },
     "v8-compile-cache-lib": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
-      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "dev": true
     },
     "vary": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
-      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="
+      "version": "1.1.2"
+    },
+    "web-streams-node": {
+      "version": "0.4.0",
+      "requires": {
+        "is-stream": "^1.1.0",
+        "readable-stream-node-to-web": "^1.0.1",
+        "web-streams-ponyfill": "^1.4.1"
+      },
+      "dependencies": {
+        "is-stream": {
+          "version": "1.1.0"
+        }
+      }
+    },
+    "web-streams-ponyfill": {
+      "version": "1.4.2"
     },
     "webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+      "version": "3.0.1"
     },
     "whatwg-url": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
       "requires": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -9217,8 +13406,6 @@
     },
     "which": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
       "dev": true,
       "requires": {
         "isexe": "^2.0.0"
@@ -9237,23 +13424,39 @@
         "is-symbol": "^1.0.3"
       }
     },
+    "winston": {
+      "version": "3.8.1",
+      "requires": {
+        "@dabh/diagnostics": "^2.0.2",
+        "async": "^3.2.3",
+        "is-stream": "^2.0.0",
+        "logform": "^2.4.0",
+        "one-time": "^1.0.0",
+        "readable-stream": "^3.4.0",
+        "safe-stable-stringify": "^2.3.1",
+        "stack-trace": "0.0.x",
+        "triple-beam": "^1.3.0",
+        "winston-transport": "^4.5.0"
+      }
+    },
+    "winston-transport": {
+      "version": "4.5.0",
+      "requires": {
+        "logform": "^2.3.2",
+        "readable-stream": "^3.6.0",
+        "triple-beam": "^1.3.0"
+      }
+    },
     "word-wrap": {
       "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
       "dev": true
     },
     "workerpool": {
       "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.1.tgz",
-      "integrity": "sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==",
       "dev": true
     },
     "wrap-ansi": {
       "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
       "requires": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -9262,54 +13465,40 @@
     },
     "wrappy": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true
+    },
+    "xml": {
+      "version": "1.0.1"
     },
     "y18n": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-      "dev": true
+      "version": "5.0.8"
     },
     "yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+      "version": "4.0.0"
     },
     "yargs": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
-      "dev": true,
+      "version": "17.5.1",
       "requires": {
         "cliui": "^7.0.2",
         "escalade": "^3.1.1",
         "get-caller-file": "^2.0.5",
         "require-directory": "^2.1.1",
-        "string-width": "^4.2.0",
+        "string-width": "^4.2.3",
         "y18n": "^5.0.5",
-        "yargs-parser": "^20.2.2"
+        "yargs-parser": "^21.0.0"
       },
       "dependencies": {
         "yargs-parser": {
-          "version": "20.2.9",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-          "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
-          "dev": true
+          "version": "21.1.0"
         }
       }
     },
     "yargs-parser": {
       "version": "20.2.4",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
-      "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
       "dev": true
     },
     "yargs-unparser": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
-      "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
       "dev": true,
       "requires": {
         "camelcase": "^6.0.0",
@@ -9320,14 +13509,10 @@
     },
     "yn": {
       "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
       "dev": true
     },
     "yocto-queue": {
       "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
-      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -30,9 +30,11 @@
     "exit": true
   },
   "dependencies": {
+    "@comunica/query-sparql-solid": "^2.2.0",
     "@inrupt/solid-client": "^1.23.1",
     "@inrupt/solid-client-authn-node": "^1.12.2",
     "@inrupt/vocab-common-rdf": "^1.0.5",
+    "asynciterator": "^3.4.2",
     "cookie-parser": "~1.4.4",
     "cookie-session": "^2.0.0",
     "debug": "~4.3.4",
@@ -47,6 +49,7 @@
     "nunjucks": "^3.2.3"
   },
   "devDependencies": {
+    "@rdfjs/types": "^1.1.0",
     "@types/chai": "^4.3.3",
     "@types/cookie-parser": "^1.4.3",
     "@types/cookie-session": "^2.0.44",
@@ -78,5 +81,8 @@
     "sinon-chai": "^3.7.0",
     "ts-node": "^10.9.1",
     "typescript": "^4.7.4"
+  },
+  "overrides": {
+    "@comunica/actor-rdf-resolve-quad-pattern-hypermedia": "2.0.5"
   }
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,6 +6,10 @@ export function getSessionKeys() {
   return ["key1", "key2"];
 }
 
+export function getGdsEssDomain() {
+  return "solid.integration.account.gov.uk";
+}
+
 export function getDeployedDomain() {
   return "prototype.solid.integration.account.gov.uk";
 }
@@ -53,4 +57,9 @@ export function getEssServiceURI(service: EssServices) {
 
 export function getCheckStoragePath(): string {
   return "private/govuk/identity/poc/credentials/vcs";
+}
+
+export function getEssFragmentIndexerWebId() {
+  return `https://fragments-indexer.inrupt.com/id`;
+  // return `https://fragments-indexer.ess.${getGdsEssDomain()}/id`
 }

--- a/src/controllers/access.ts
+++ b/src/controllers/access.ts
@@ -12,11 +12,21 @@ import {
   getDatetime,
 } from "@inrupt/solid-client";
 import { RDF, DCTERMS } from "@inrupt/vocab-common-rdf";
+// eslint-disable-next-line import/no-unresolved
+import * as _RDF from "@rdfjs/types";
 import { getOrCreateDataset, getDatasetUri } from "../lib/pod";
 
 import SessionError from "../errors";
 
 const GOV_UK_ACCESS_LOG_ENTRY = "https://vocab.account.gov.uk/AccessLogEntry";
+
+// The GDS ESS Fragments service.
+const GOV_UK_GDS_ESS_ENDPOINT_FRAGMENT =
+  "https://fragments.ess.solid.integration.account.gov.uk/qpf?storage=";
+// The Pod Spaces ESS Fragments service.
+// const GOV_UK_GDS_ESS_ENDPOINT_FRAGMENT = "https://fragments.inrupt.com/qpf?storage=";
+
+const { QueryEngine } = require("@comunica/query-sparql-solid");
 
 export async function accessGet(req: Request, res: Response): Promise<void> {
   const session = await getSessionFromStorage(req.session?.sessionId);
@@ -33,6 +43,137 @@ export async function accessGet(req: Request, res: Response): Promise<void> {
         getThing(dataset, datasetUri) as Thing,
         DCTERMS.created
       );
+
+      // Just here to show-by-example...
+      // Query and iterate over all triples from our user's WebID Profile
+      // Document...
+      try {
+        console.log(
+          `Querying for triples from WebID Profile Document specifically...`
+        );
+        const myEngine = new QueryEngine();
+        const webIdProfileDocStream = await myEngine.queryBindings(
+          `
+          SELECT * WHERE {
+              ?s ?p ?o
+          } LIMIT 100`,
+          {
+            sources: [session.info.webId], // Sets WebID profile document as query source.
+          }
+        );
+
+        console.log(`Showing resulting triples:`);
+        webIdProfileDocStream.on("data", (binding: _RDF.Bindings) => {
+          console.log(
+            `SPARQL: s [${binding.get("s")!.value}] p [${
+              binding.get("p")!.value
+            }] o [${binding.get("o")!.value}]`
+          );
+        });
+
+        await new Promise<void>((resolve) => {
+          webIdProfileDocStream.on("end", () => {
+            console.log(`End of result stream.`);
+            resolve();
+          });
+        });
+
+        // const webIdProfileDocBindings: [] = await webIdProfileDocStream.toArray();
+        // webIdProfileDocBindings.forEach((binding) => {
+        //   console.log(`SPARQL: s [${(binding as Map<string, any>).get('s').value}] p [${(binding as Map<string, any>).get('p').value}] o [${(binding as Map<string, any>).get('o').value}]`);
+        // });
+      } catch (error) {
+        const msg = `ERROR trying query user's WebID Profile Document at [${session.info.webId}]: ${error}`;
+        console.log(msg);
+      }
+
+      // Just here to show-by-example...
+      // Query just for the `pim:storage` value from the user's WebID Profile
+      // Document...
+      let storageIri;
+      let storageStream;
+      try {
+        console.log(`Querying for 'pim:storage' specifically...`);
+        const myEngine = new QueryEngine();
+        storageStream = await myEngine.queryBindings(
+          `
+          PREFIX pim: <http://www.w3.org/ns/pim/space#>
+          SELECT ?storageIri WHERE {
+              <${session.info.webId}> pim:storage ?storageIri
+          }`,
+          {
+            sources: [session.info.webId], // Sets WebID profile document as query source.
+          }
+        );
+
+        const storageBindings = await storageStream.toArray();
+        if (storageBindings && storageBindings.length !== 1) {
+          console.log(
+            `Expected one, and only one, value for 'pim:storage' for WebID [${session.info.webId}], but got [${storageBindings.length}] values!`
+          );
+        } else {
+          storageIri = storageBindings[0].get("storageIri").value;
+          console.log(`Storage IRI: [${storageIri}]`);
+        }
+      } catch (error) {
+        const msg = `ERROR trying query this user's WebID Profile Document (at [${session.info.webId}]) for the location of their Pod storage: ${error}`;
+        console.log(msg);
+      }
+
+      let logStream;
+      try {
+        // Query for data from the user's Pod storage...
+        const qpfEndpoint = `${GOV_UK_GDS_ESS_ENDPOINT_FRAGMENT}${encodeURIComponent(
+          storageIri
+        )}`;
+        console.log(
+          `Querying for last Access Log timestamp [${qpfEndpoint}]...`
+        );
+        console.log(
+          `Session logged in: [${session.info.isLoggedIn}], WebID: [${session.info.webId}], ...`
+        );
+
+        const myEngine = new QueryEngine();
+        logStream = await myEngine.queryBindings(
+          `
+          PREFIX dcterms: <http://purl.org/dc/terms/>
+          SELECT ?lastAccessLogTimestamp WHERE {
+            GRAPH ?g {
+               ?s a <https://vocab.account.gov.uk/AccessLogEntry> .
+             ?s dcterms:created ?lastAccessLogTimestamp .
+            }
+          }`,
+          {
+            // sources: [{type: "hypermedia", value: qpfEndpoint}],
+            sources: [qpfEndpoint],
+            "@comunica/actor-http-inrupt-solid-client-authn:session": session,
+            httpTimeout: 5000,
+            logLevel: "debug",
+          }
+        );
+
+        try {
+          const logBindings = await logStream.toArray();
+          if (logBindings && logBindings.length === 1) {
+            const lastAccessLogTimestamp = logBindings[0].get(
+              "lastAccessLogTimestamp"
+            ).value;
+            console.log(
+              `Last Access Log timestamp: [${lastAccessLogTimestamp}]`
+            );
+          } else {
+            console.log(
+              `Got [${logBindings.length}] access log entries - expected just 1!`
+            );
+          }
+        } catch (error) {
+          const msg = `ERROR processing result stream from Access Log query: ${error}`;
+          console.log(msg);
+        }
+      } catch (error) {
+        const msg = `ERROR querying for Access Logs: ${error}`;
+        console.log(msg);
+      }
 
       res.render("access/show", { created });
     } catch (fetchError) {

--- a/src/controllers/identity/save.ts
+++ b/src/controllers/identity/save.ts
@@ -31,7 +31,6 @@ export function saveGet(req: Request, res: Response) {
 
 export async function savePost(req: Request, res: Response): Promise<void> {
   const session = await getSessionFromStorage(req.session?.sessionId);
-
   if (session && req.session) {
     req.session.webId = session.info.webId;
     const containerUri = await getDatasetUri(

--- a/src/controllers/login.ts
+++ b/src/controllers/login.ts
@@ -9,8 +9,12 @@ import {
   getClientId,
   getEssServiceURI,
   EssServices,
+  getEssFragmentIndexerWebId,
 } from "../config";
-import { createProfileAndPod } from "../lib/pod";
+import {
+  createProfileAndPod,
+  ensureFragmentIndexerGrantedAccess,
+} from "../lib/pod";
 
 export function loginGet(req: Request, res: Response): void {
   const session = new Session();
@@ -39,6 +43,10 @@ export async function callbackGet(req: Request, res: Response): Promise<void> {
     const response = await session.fetch(session.info.webId);
     if (response.status === 404) {
       await createProfileAndPod(session);
+      await ensureFragmentIndexerGrantedAccess(
+        session,
+        getEssFragmentIndexerWebId()
+      );
     }
 
     if (req.session && req.session.returnUri) {


### PR DESCRIPTION
DRAFT: This PR adds query demonstration code to the access log code, i.e., to `src/controllers/access.ts`.
It demonstrates how to query using SPARQL (using a client-side open-source library named Comunica, which breaks W3C standard SPARQL queries down into multiple primitive QPF queries that get fired to ESS).
It shows how to query for public data (like the user's WebID Profile document), which doesn't require any authentication, and it also shows how to query for private data (like the previously written access log resource in the user's Pod), which does require authentication.