### PR TITLE
BAU: make dbs/pta start pages look more like GOVUK

### DIFF
--- a/src/public/stylesheets/application.scss
+++ b/src/public/stylesheets/application.scss
@@ -152,5 +152,8 @@
   color: black;
   font-size: 16px;
   top: 2px;
+}
 
+.related-items {
+  border-top: 2px solid govuk-colour("blue");
 }

--- a/src/views/dbs/request-a-basic-dbs-check.njk
+++ b/src/views/dbs/request-a-basic-dbs-check.njk
@@ -1,8 +1,21 @@
-{% extends "layouts/base.njk" %}
+{% extends "layouts/govuk.njk" %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% set pageTitleName = "dbs.pages.requestBasicCheck.title" | translate %}
-{% set serviceName = "GOV.UK" %}
+{% set breadcrumbItems = [
+  {
+    text: "Home",
+    href: "/"
+  },
+  {
+    text: "Working, jobs and pensions",
+    href: "https://www.gov.uk/browse/working"
+  },
+  {
+    text: "Finding a job",
+    href: "https://www.gov.uk/browse/working/finding-job"
+  }
+] %}
 
 {% block content %}
   <h1 class="govuk-heading-xl">
@@ -93,22 +106,23 @@
     </div>
 {% endblock %}
 {% block sideContent %}
-  <h2 class="govuk-heading-m" id="subsection-title">
-    Related content
-  </h2>
-  <nav role="navigation" aria-labelledby="subsection-title">
-    <ul class="govuk-list govuk-!-font-size-16">
-      <li>
-        <a class="govuk-link"  class="govuk-link" href="#">
-          Criminal record checks when you apply for a role
-        </a>
-      </li>
-      <li>
-        <a class="govuk-link"  class="govuk-link" href="#">
-          Find out which DBS check is right for your employee
-        </a>
-      </li>
-
-    </ul>
-  </nav>
+  <aside class="related-items" role="complementary" lang="en">
+    <h2 class="govuk-heading-s govuk-!-padding-top-4" id="subsection-title">
+      Related content
+    </h2>
+    <nav role="navigation" aria-labelledby="subsection-title">
+      <ul class="govuk-list govuk-!-font-size-16">
+        <li>
+          <a class="govuk-link"  class="govuk-link" href="https://www.gov.uk/criminal-record-checks-apply-role">
+            Criminal record checks when you apply for a role
+          </a>
+        </li>
+        <li>
+          <a class="govuk-link"  class="govuk-link" href="https://www.gov.uk/find-out-dbs-check">
+            Find out which DBS check is right for your employee
+          </a>
+        </li>
+      </ul>
+    </nav>
+  </aside>
 {% endblock %}

--- a/src/views/layouts/base.njk
+++ b/src/views/layouts/base.njk
@@ -34,12 +34,14 @@
 
 {% block main %}
   <div class="govuk-width-container {{ containerClasses }}">
-    {{ govukPhaseBanner({
-        tag: {
-            text: 'general.phaseBanner.tag' | translate
-        },
-        html: 'general.phaseBanner.text' | translate | replace ("[supportUrl]", authFrontEndUrl + "/contact-us?supportType=PUBLIC")
-    }) }}
+    {% if not hidePhaseBanner %}
+      {{ govukPhaseBanner({
+          tag: {
+              text: 'general.phaseBanner.tag' | translate
+          },
+          html: 'general.phaseBanner.text' | translate | replace ("[supportUrl]", authFrontEndUrl + "/contact-us?supportType=PUBLIC")
+      }) }}
+    {% endif %}
     {% if backLink %}
       <a href="{{backLink}}" class="govuk-back-link govuk-!-margin-bottom-0">{{'general.back' | translate}}</a>
     {% endif %}

--- a/src/views/layouts/govuk.njk
+++ b/src/views/layouts/govuk.njk
@@ -1,0 +1,13 @@
+{% extends "layouts/base.njk" %}
+{% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
+{% set serviceName = "GOV.UK" %}
+{% set hidePhaseBanner = true %}
+{% set containerClasses = "govuk-!-margin-top-3" %}
+
+{% block beforeContent %}
+  <div lang="en">
+    {{ govukBreadcrumbs({
+      items: breadcrumbItems
+    }) }}
+  </div>
+{% endblock %}

--- a/src/views/personal-tax/sign-in-or-set-up.njk
+++ b/src/views/personal-tax/sign-in-or-set-up.njk
@@ -1,8 +1,21 @@
-{% extends "layouts/base.njk" %}
+{% extends "layouts/govuk.njk" %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% set pageTitleName = "personalTax.pages.signInOrSetUp.title" | translate %}
-{% set serviceName = "GOV.UK" %}
+{% set breadcrumbItems = [
+  {
+    text: "Home",
+    href: "/"
+  },
+  {
+    text: "Money and tax",
+    href: "https://www.gov.uk/browse/tax"
+  },
+  {
+    text: "Dealing with HMRC",
+    href: "https://www.gov.uk/browse/tax/dealing-with-hmrc"
+  }
+] %}
 
 {% block content %}
   <h1 class="govuk-heading-xl">
@@ -38,19 +51,19 @@
     <li>{{ "personalTax.pages.signInOrSetUp.listItem12" | translate }}</li>
   </ul>
 
-  <aside class="app-related-items govuk-!-margin-top-8" role="complementary" style="border-top: 2px solid	#1d70b8" lang="en">
+  <aside class="related-items govuk-!-margin-top-8" role="complementary" lang="en">
       <h3 class="govuk-heading-s govuk-!-padding-top-4" id="subsection-title">
         Explore the topic
       </h3>
       <nav role="navigation" aria-labelledby="subsection-title">
         <ul class="govuk-list govuk-!-font-size-16">
           <li>
-            <a href="#" class="govuk-!-font-weight-bold govuk-link">
+            <a href="https://www.gov.uk/browse/tax/dealing-with-hmrc" class="govuk-link">
               Dealing with HMRC
             </a>
           </li>
           <li>
-            <a href="#" class="govuk-!-font-weight-bold govuk-link">
+            <a href="https://www.gov.uk/browse/tax/income-tax" class="govuk-link">
               Income Tax
             </a>
           </li>


### PR DESCRIPTION
Make our fake "GOVUK" pages in the app look a bit more like GOVUK and a bit less like a service page through removal of the phase banner, addition of breadcrumbs and minor spacing tweaks.

Not adding the super nav to these pages right now as it would add a lot of CSS and JS to the payload for very little benefit, so hopefully the basic GOVUK nav will do.