### PR TITLE
GUA-311 - Access Grant Flow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@inrupt/solid-client": "^1.23.1",
         "@inrupt/solid-client-access-grants": "^1.0.2",
         "@inrupt/solid-client-authn-node": "^1.12.2",
+        "@inrupt/solid-client-vc": "^0.5.0",
         "@inrupt/vocab-common-rdf": "^1.0.5",
         "cookie-parser": "~1.4.4",
         "cookie-session": "^2.0.0",
@@ -223,6 +224,15 @@
       },
       "engines": {
         "node": "^14.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/@inrupt/solid-client-vc": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-vc/-/solid-client-vc-0.5.0.tgz",
+      "integrity": "sha512-Rglf0I47hhkZ/kOjM2Vtxph6sh8ZzxHN/vUOYOMZR/fiRtN8DotCFASBZ3qgMbRYmroKCxs8QDEHF36sq3ftrQ==",
+      "dependencies": {
+        "@inrupt/solid-client": "^1.15.0",
+        "cross-fetch": "^3.1.4"
       }
     },
     "node_modules/@inrupt/solid-common-vocab": {
@@ -1091,6 +1101,11 @@
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
       "integrity": "sha512-eBvWn1lvIApYMhzQMsu9ciLfkBY499mFZlNqG+/9WR7PVlroQw0vG30cOQQbaKz3sCEc44TAOu2ykzqXSNnwag==",
       "dev": true
+    },
+    "node_modules/auth-header": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/auth-header/-/auth-header-1.0.0.tgz",
+      "integrity": "sha512-CPPazq09YVDUNNVWo4oSPTQmtwIzHusZhQmahCKvIsk0/xH6U3QsMAv3sM+7+Q0B1K2KJ/Q38OND317uXs4NHA=="
     },
     "node_modules/axe-core": {
       "version": "4.4.3",
@@ -4179,6 +4194,14 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse-link-header": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/parse-link-header/-/parse-link-header-2.0.0.tgz",
+      "integrity": "sha512-xjU87V0VyHZybn2RrCX5TIFGxTVZE6zqqZWMPlIKiSKuWh/X5WZdt+w1Ki1nXB+8L/KtL+nZ4iq+sfI6MrhhMw==",
+      "dependencies": {
+        "xtend": "~4.0.1"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -4412,6 +4435,11 @@
       "dependencies": {
         "@rdfjs/types": "*"
       }
+    },
+    "node_modules/rdf-namespaces": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/rdf-namespaces/-/rdf-namespaces-1.9.2.tgz",
+      "integrity": "sha512-Gf/sZLUo758fDLnqZs0laG0IbOm06yq1fVrCnFhOEcGyTKt9hh7lcs+7L0DAQquacwARqfsJIOcJDsfdZRU/Wg=="
     },
     "node_modules/react-is": {
       "version": "16.13.1",
@@ -5291,6 +5319,14 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true
     },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
     "node_modules/y18n": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
@@ -5471,6 +5507,22 @@
         "n3": "^1.10.0"
       }
     },
+    "@inrupt/solid-client-access-grants": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-access-grants/-/solid-client-access-grants-1.0.2.tgz",
+      "integrity": "sha512-Cs8fQP1DGnyLGUYkbULQCMBs/8SO9HZX2OX8m47OUwNtJzP0WFMuMD2W59fF9NdSlN3lNAi8S03Ge6W0PPTgHw==",
+      "requires": {
+        "@inrupt/solid-client": "^1.18.0",
+        "@inrupt/solid-client-authn-core": "^1.11.2",
+        "@inrupt/solid-client-vc": "^0.5.0",
+        "auth-header": "^1.0.0",
+        "cross-fetch": "^3.1.4",
+        "events": "^3.3.0",
+        "jose": "^4.8.1",
+        "parse-link-header": "^2.0.0",
+        "rdf-namespaces": "^1.9.2"
+      }
+    },
     "@inrupt/solid-client-authn-core": {
       "version": "1.12.2",
       "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-core/-/solid-client-authn-core-1.12.2.tgz",
@@ -5496,6 +5548,15 @@
         "jose": "^4.3.7",
         "openid-client": "^5.1.0",
         "uuid": "^8.3.2"
+      }
+    },
+    "@inrupt/solid-client-vc": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-vc/-/solid-client-vc-0.5.0.tgz",
+      "integrity": "sha512-Rglf0I47hhkZ/kOjM2Vtxph6sh8ZzxHN/vUOYOMZR/fiRtN8DotCFASBZ3qgMbRYmroKCxs8QDEHF36sq3ftrQ==",
+      "requires": {
+        "@inrupt/solid-client": "^1.15.0",
+        "cross-fetch": "^3.1.4"
       }
     },
     "@inrupt/solid-common-vocab": {
@@ -6182,6 +6243,11 @@
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
       "integrity": "sha512-eBvWn1lvIApYMhzQMsu9ciLfkBY499mFZlNqG+/9WR7PVlroQw0vG30cOQQbaKz3sCEc44TAOu2ykzqXSNnwag==",
       "dev": true
+    },
+    "auth-header": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/auth-header/-/auth-header-1.0.0.tgz",
+      "integrity": "sha512-CPPazq09YVDUNNVWo4oSPTQmtwIzHusZhQmahCKvIsk0/xH6U3QsMAv3sM+7+Q0B1K2KJ/Q38OND317uXs4NHA=="
     },
     "axe-core": {
       "version": "4.4.3",
@@ -8486,6 +8552,14 @@
         "callsites": "^3.0.0"
       }
     },
+    "parse-link-header": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/parse-link-header/-/parse-link-header-2.0.0.tgz",
+      "integrity": "sha512-xjU87V0VyHZybn2RrCX5TIFGxTVZE6zqqZWMPlIKiSKuWh/X5WZdt+w1Ki1nXB+8L/KtL+nZ4iq+sfI6MrhhMw==",
+      "requires": {
+        "xtend": "~4.0.1"
+      }
+    },
     "parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -8645,6 +8719,11 @@
       "requires": {
         "@rdfjs/types": "*"
       }
+    },
+    "rdf-namespaces": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/rdf-namespaces/-/rdf-namespaces-1.9.2.tgz",
+      "integrity": "sha512-Gf/sZLUo758fDLnqZs0laG0IbOm06yq1fVrCnFhOEcGyTKt9hh7lcs+7L0DAQquacwARqfsJIOcJDsfdZRU/Wg=="
     },
     "react-is": {
       "version": "16.13.1",
@@ -9282,6 +9361,11 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true
+    },
+    "xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
     },
     "y18n": {
       "version": "5.0.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@inrupt/solid-client": "^1.23.1",
+        "@inrupt/solid-client-access-grants": "^1.0.2",
         "@inrupt/solid-client-authn-node": "^1.12.2",
         "@inrupt/vocab-common-rdf": "^1.0.5",
         "cookie-parser": "~1.4.4",
@@ -173,6 +174,22 @@
       },
       "engines": {
         "node": ">=14.0"
+      }
+    },
+    "node_modules/@inrupt/solid-client-access-grants": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-access-grants/-/solid-client-access-grants-1.0.2.tgz",
+      "integrity": "sha512-Cs8fQP1DGnyLGUYkbULQCMBs/8SO9HZX2OX8m47OUwNtJzP0WFMuMD2W59fF9NdSlN3lNAi8S03Ge6W0PPTgHw==",
+      "dependencies": {
+        "@inrupt/solid-client": "^1.18.0",
+        "@inrupt/solid-client-authn-core": "^1.11.2",
+        "@inrupt/solid-client-vc": "^0.5.0",
+        "auth-header": "^1.0.0",
+        "cross-fetch": "^3.1.4",
+        "events": "^3.3.0",
+        "jose": "^4.8.1",
+        "parse-link-header": "^2.0.0",
+        "rdf-namespaces": "^1.9.2"
       }
     },
     "node_modules/@inrupt/solid-client-authn-core": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   },
   "dependencies": {
     "@inrupt/solid-client": "^1.23.1",
+    "@inrupt/solid-client-access-grants": "^1.0.2",
     "@inrupt/solid-client-authn-node": "^1.12.2",
     "@inrupt/vocab-common-rdf": "^1.0.5",
     "cookie-parser": "~1.4.4",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@inrupt/solid-client": "^1.23.1",
     "@inrupt/solid-client-access-grants": "^1.0.2",
     "@inrupt/solid-client-authn-node": "^1.12.2",
+    "@inrupt/solid-client-vc": "^0.5.0",
     "@inrupt/vocab-common-rdf": "^1.0.5",
     "cookie-parser": "~1.4.4",
     "cookie-session": "^2.0.0",

--- a/src/controllers/account.ts
+++ b/src/controllers/account.ts
@@ -3,6 +3,9 @@ import {
   getSessionFromStorage,
   Session,
 } from "@inrupt/solid-client-authn-node";
+
+import { VerifiableCredential } from "@inrupt/solid-client-vc";
+
 import { deleteFile } from "@inrupt/solid-client";
 
 import { getCheckStoragePath } from "../config";
@@ -112,4 +115,21 @@ export async function deleteYourProofOfIdPost(
   }
 
   res.redirect("/account/settings/your-proof-of-identity");
+}
+
+const isVerifiableCredential = (vc: any): vc is VerifiableCredential =>
+  typeof vc === "object" && "credentialSubject" in vc;
+
+function decodeAccessRequestVC(encodedJwt: string): VerifiableCredential {
+  if (!encodedJwt) {
+    throw new Error("no encoded token found");
+  }
+
+  const buff = Buffer.from(encodedJwt, "base64");
+  const decodedToken = JSON.parse(buff.toString("utf-8"));
+
+  if (!isVerifiableCredential(decodedToken)) {
+    throw new Error("invalid token object");
+  }
+  return decodedToken;
 }

--- a/src/controllers/account.ts
+++ b/src/controllers/account.ts
@@ -10,7 +10,11 @@ import {
   denyAccessRequest,
 } from "@inrupt/solid-client-access-grants";
 
-import { deleteFile, saveSolidDatasetAt } from "@inrupt/solid-client";
+import {
+  createSolidDataset,
+  deleteFile,
+  saveSolidDatasetAt,
+} from "@inrupt/solid-client";
 
 import { getCheckStoragePath } from "../config";
 import {
@@ -210,10 +214,13 @@ export async function accessManagementPost(
       const resourceUri =
         accessRequest.credentialSubject.hasConsent.forPersonalData[0];
 
-      const dataset = await getOrCreateDataset(solidSession, resourceUri);
-      await saveSolidDatasetAt(resourceUri, dataset, {
-        fetch: solidSession.fetch,
-      });
+      try {
+        await getOrCreateDataset(solidSession, resourceUri);
+      } catch (fetchError) {
+        await saveSolidDatasetAt(resourceUri, createSolidDataset(), {
+          fetch: solidSession.fetch,
+        });
+      }
 
       if (consent === "yes") {
         const approvedVc = await approveAccessRequest(requestVcUrl, undefined, {

--- a/src/controllers/account.ts
+++ b/src/controllers/account.ts
@@ -133,3 +133,21 @@ function decodeAccessRequestVC(encodedJwt: string): VerifiableCredential {
   }
   return decodedToken;
 }
+
+function validateAccessRequestVC(
+  decodedVC: VerifiableCredential
+): true | false {
+  // Not implimented but left here as a hint that this is logic we'd need for
+  // a production service, we should validate the
+  const notImplimented = true;
+
+  if (notImplimented) {
+    return true;
+  }
+
+  const err = "VC is invalid in some way";
+  console.log(err);
+  console.log(decodedVC);
+
+  return false;
+}

--- a/src/controllers/nino.ts
+++ b/src/controllers/nino.ts
@@ -1,10 +1,25 @@
-import { getSessionFromStorage } from "@inrupt/solid-client-authn-node";
+import {
+  getSessionFromStorage,
+  Session,
+} from "@inrupt/solid-client-authn-node";
 import { Request, Response } from "express";
 import { getHostname } from "../config";
 import SessionError from "../errors";
 import { getDatasetUri, writeCheckToPod } from "../lib/pod";
 import buildNiNumberArtifacts from "../lib/nationalInsurance";
 
+
+async function fakeOIDCLogin(): Promise<Session> {
+  const session = new Session();
+  return session
+    .login({
+      // 2. Use the authenticated credentials to log in the session.
+      clientId: "cd68b569-0b92-42dd-9993-879909502979",
+      clientSecret: "7bd94621-21bf-4703-b9a2-5691d886854d",
+      oidcIssuer: "https://openid.ess.solid.integration.account.gov.uk/",
+    })
+    .then(() => session);
+}
 export function startGet(req: Request, res: Response): void {
   if (req.session) {
     const returnUri = req.params.returnUri

--- a/src/controllers/nino.ts
+++ b/src/controllers/nino.ts
@@ -131,7 +131,10 @@ export async function beginAccessGrantsFlow(
   }
 }
 
-export async function saveNinoGet(req: Request, res: Response): Promise<void> {
+export async function saveNinoWithAccessGrantGet(
+  req: Request,
+  res: Response
+): Promise<void> {
   const requestorSession = await fakeOIDCLogin();
 
   const resourceOwnerSession = await getSessionFromStorage(

--- a/src/controllers/nino.ts
+++ b/src/controllers/nino.ts
@@ -50,7 +50,7 @@ function requestAccessToWriteNino(
   // Call `issueAccessRequest` to create an access request
   return issueAccessRequest(
     {
-      access: { write: true },
+      access: { read: true, write: true },
       resourceOwner,
       resources: [ninoContainerUri],
       expirationDate: accessExpiration,

--- a/src/controllers/nino.ts
+++ b/src/controllers/nino.ts
@@ -34,6 +34,8 @@ async function fakeOIDCLogin(): Promise<Session> {
       clientId: "cd68b569-0b92-42dd-9993-879909502979",
       clientSecret: "7bd94621-21bf-4703-b9a2-5691d886854d",
       oidcIssuer: "https://openid.ess.solid.integration.account.gov.uk/",
+      // Note that using a Bearer token is mandatory for the UMA access token to be valid.
+      tokenType: "Bearer",
     })
     .then(() => session);
 }

--- a/src/controllers/nino.ts
+++ b/src/controllers/nino.ts
@@ -24,7 +24,7 @@ type WebId = string;
 type Uri = string;
 
 const ninoContainer =
-  "private/govuk/identity/poc/credentials/national-insurance-number/";
+  "private/govuk/identity/poc/credentials/national-insurance-number";
 
 async function fakeOIDCLogin(): Promise<Session> {
   const session = new Session();
@@ -54,7 +54,7 @@ function requestAccessToWriteNino(
     {
       access: { read: true, write: true },
       resourceOwner,
-      resources: [ninoContainerUri],
+      resources: [`${ninoContainerUri}/metadata`, `${ninoContainerUri}/check`],
       expirationDate: accessExpiration,
       purpose: [`${getHostname()}/purposes#write-nino`],
     },

--- a/src/controllers/nino.ts
+++ b/src/controllers/nino.ts
@@ -14,7 +14,7 @@ import {
 import { createSolidDataset, setThing } from "@inrupt/solid-client";
 
 import { Request, Response } from "express";
-import { getHostname } from "../config";
+import { EssServices, getEssServiceURI, getHostname } from "../config";
 import SessionError from "../errors";
 import { getDatasetUri } from "../lib/pod";
 
@@ -33,7 +33,7 @@ async function fakeOIDCLogin(): Promise<Session> {
       // 2. Use the authenticated credentials to log in the session.
       clientId: "cd68b569-0b92-42dd-9993-879909502979",
       clientSecret: "7bd94621-21bf-4703-b9a2-5691d886854d",
-      oidcIssuer: "https://openid.ess.solid.integration.account.gov.uk/",
+      oidcIssuer: getEssServiceURI(EssServices.OpenId),
       // Note that using a Bearer token is mandatory for the UMA access token to be valid.
       tokenType: "Bearer",
     })
@@ -47,7 +47,7 @@ function requestAccessToWriteNino(
 ): Promise<AccessRequest | null> {
   // DWP sets the requested access (if granted) to expire in 5 minutes.
   const accessExpiration = new Date(Date.now() + 5 * 60000);
-  const accessEndpoint = `https://vc.ess.solid.integration.account.gov.uk`;
+  const accessEndpoint = getEssServiceURI(EssServices.Vc);
 
   // Call `issueAccessRequest` to create an access request
   return issueAccessRequest(

--- a/src/controllers/nino.ts
+++ b/src/controllers/nino.ts
@@ -16,6 +16,9 @@ import buildNiNumberArtifacts from "../lib/nationalInsurance";
 type WebId = string;
 type Uri = string;
 
+const ninoContainer =
+  "private/govuk/identity/poc/credentials/national-insurance-number/";
+
 async function fakeOIDCLogin(): Promise<Session> {
   const session = new Session();
   return session
@@ -115,7 +118,7 @@ export async function beginAccessGrantsFlow(
     if (resourceOwnerWebId) {
       const ninoContainerUri = await getDatasetUri(
         resourceOwnerSession,
-        "private/govuk/identity/poc/credentials/national-insurance-number/"
+        ninoContainer
       );
 
       const requestorSession = await fakeOIDCLogin();

--- a/src/controllers/nino.ts
+++ b/src/controllers/nino.ts
@@ -86,28 +86,6 @@ export function verifiedNinoGet(req: Request, res: Response): void {
   res.render("nino/weve-verified-your-number");
 }
 
-export async function verifiedNinoPost(
-  req: Request,
-  res: Response
-): Promise<void> {
-  const session = await getSessionFromStorage(req.session?.sessionId);
-
-  if (session && req.session) {
-    req.session.webId = session.info.webId;
-    const containerUri = await getDatasetUri(
-      session,
-      "private/govuk/identity/poc/credentials/vcs"
-    );
-
-    const niNumberArtifacts = buildNiNumberArtifacts(req.session, containerUri);
-    await writeCheckToPod(session, niNumberArtifacts);
-
-    res.redirect("/nino/youve-saved-your-number");
-  } else {
-    throw new SessionError();
-  }
-}
-
 export function savedNinoGet(req: Request, res: Response): void {
   res.render("nino/youve-saved-your-number");
 }

--- a/src/lib/nationalInsurance.ts
+++ b/src/lib/nationalInsurance.ts
@@ -19,7 +19,6 @@ function buildNiNumberJWT(
   const payload = {
     nationalInsuranceNumber: session.nino,
   };
-
   return generateJWT(payload, session.webId);
 }
 
@@ -27,8 +26,8 @@ export default function buildNiNumberArtifacts(
   session: CookieSessionInterfaces.CookieSessionObject,
   containerUri: string
 ): CheckArtifacts {
-  const fileUri = `${containerUri}/ni/check`;
-  const metadataUri = `${containerUri}/ni/metadata`;
+  const fileUri = `${containerUri}/check`;
+  const metadataUri = `${containerUri}/metadata`;
 
   const file = new Blob([buildNiNumberJWT(session)], {
     type: "application/json",

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -259,6 +259,14 @@
         "paragraph2": "You will need to go through the process of proving your identity next time you use a service that requires it.",
         "buttonText": "Delete identity information",
         "cancelLink": "Do not delete your information"
+      },
+      "accessManagement": {
+        "title": "Access Management",
+        "consentQuestion": "Do you agree?",
+        "hint": "This will authorise information moving around",
+        "affirmative": "Yes I give permission",
+        "negative": "No I deny permission",
+        "buttonText": "Submit"
       }
     }
   },

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -259,6 +259,14 @@
         "paragraph2": "You will need to go through the process of proving your identity next time you use a service that requires it.",
         "buttonText": "Delete identity information",
         "cancelLink": "Do not delete your information"
+      },
+      "accessManagement": {
+        "title": "Access Management",
+        "consentQuestion": "Do you agree?",
+        "hint": "This will authorise information moving around",
+        "affirmative": "Yes I give permission",
+        "negative": "No I deny permission",
+        "buttonText": "Submit"
       }
     }
   },

--- a/src/routes/account.ts
+++ b/src/routes/account.ts
@@ -8,6 +8,7 @@ import {
   yourProofOfIdGet,
   deleteYourProofOfIdGet,
   deleteYourProofOfIdPost,
+  accessManagementGet,
 } from "../controllers/account";
 
 const router = express.Router();
@@ -23,5 +24,6 @@ router.get("/settings/activity", accountActivityGet);
 router.get("/settings/your-proof-of-identity", yourProofOfIdGet);
 router.get("/settings/your-proof-of-identity/delete", deleteYourProofOfIdGet);
 router.post("/settings/your-proof-of-identity/delete", deleteYourProofOfIdPost);
+router.get("/access-management", accessManagementGet);
 
 export default router;

--- a/src/routes/account.ts
+++ b/src/routes/account.ts
@@ -9,9 +9,12 @@ import {
   deleteYourProofOfIdGet,
   deleteYourProofOfIdPost,
   accessManagementGet,
+  accessManagementPost,
 } from "../controllers/account";
 
 const router = express.Router();
+
+router.post("/access-management", accessManagementPost);
 
 /* All following routes require someone to be logged in first */
 router.use((req: Request, res: Response, next: NextFunction) => {

--- a/src/routes/nino.ts
+++ b/src/routes/nino.ts
@@ -5,7 +5,7 @@ import {
   enterNinoPost,
   startGet,
   verifiedNinoGet,
-  verifiedNinoPost,
+  beginAccessGrantsFlow,
   savedNinoGet,
 } from "../controllers/nino";
 import redirectIfNotLoggedIn from "../lib/middleware/redirectIfNotLoggedIn";
@@ -20,7 +20,7 @@ router.get("/", startGet);
 router.get("/enter-your-number", enterNinoGet);
 router.post("/enter-your-number", enterNinoPost);
 router.get("/weve-verified-your-number", verifiedNinoGet);
-router.post("/weve-verified-your-number", verifiedNinoPost);
+router.post("/weve-verified-your-number", beginAccessGrantsFlow);
 router.get("/youve-saved-your-number", savedNinoGet);
 router.get("/continue", continueGet);
 

--- a/src/routes/nino.ts
+++ b/src/routes/nino.ts
@@ -7,7 +7,7 @@ import {
   verifiedNinoGet,
   beginAccessGrantsFlow,
   savedNinoGet,
-  saveNinoGet,
+  saveNinoWithAccessGrantGet,
 } from "../controllers/nino";
 import redirectIfNotLoggedIn from "../lib/middleware/redirectIfNotLoggedIn";
 
@@ -20,9 +20,9 @@ router.use((req: Request, res: Response, next: NextFunction) => {
 router.get("/", startGet);
 router.get("/enter-your-number", enterNinoGet);
 router.post("/enter-your-number", enterNinoPost);
-router.get("/save-number", saveNinoGet);
 router.get("/weve-verified-your-number", verifiedNinoGet);
 router.post("/weve-verified-your-number", beginAccessGrantsFlow);
+router.get("/save-number", saveNinoWithAccessGrantGet);
 router.get("/youve-saved-your-number", savedNinoGet);
 router.get("/continue", continueGet);
 

--- a/src/routes/nino.ts
+++ b/src/routes/nino.ts
@@ -7,6 +7,7 @@ import {
   verifiedNinoGet,
   beginAccessGrantsFlow,
   savedNinoGet,
+  saveNinoGet,
 } from "../controllers/nino";
 import redirectIfNotLoggedIn from "../lib/middleware/redirectIfNotLoggedIn";
 
@@ -19,6 +20,7 @@ router.use((req: Request, res: Response, next: NextFunction) => {
 router.get("/", startGet);
 router.get("/enter-your-number", enterNinoGet);
 router.post("/enter-your-number", enterNinoPost);
+router.get("/save-number", saveNinoGet);
 router.get("/weve-verified-your-number", verifiedNinoGet);
 router.post("/weve-verified-your-number", beginAccessGrantsFlow);
 router.get("/youve-saved-your-number", savedNinoGet);

--- a/src/views/account/access-management.njk
+++ b/src/views/account/access-management.njk
@@ -1,0 +1,70 @@
+{% extends "layouts/account.njk" %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% set pageTitleName = 'account.pages.accessManagement.title' | translate %}
+{% set activeNavLink = '/account/access-management' %}
+{% set hasProofOfId = true %}
+
+{% block content %}
+  <h1 class="govuk-heading-l govuk-!-margin-bottom-7">{{ 'account.pages.accessManagement.title' | translate }}</h1>
+
+  <p>
+    Who's Asking for Permission: {{ credentialSubject["id"]}}
+  </p>
+
+  <p>
+    What: {{ credentialSubject["hasConsent"]["mode"] }}
+  </p>
+
+  <p>
+    Status: {{ credentialSubject["hasConsent"]["hasStatus"] }}
+  </p>
+
+  <p>
+    What: {{ credentialSubject["hasConsent"]["forPersonalData"] }}
+  </p>
+
+  <p>
+    For what purpose: {{ credentialSubject["hasConsent"]["forPurpose"] }}
+  </p>
+
+  <p>
+    Subject of the request: {{ credentialSubject["hasConsent"]["isConsentForDataSubject"] }}
+  </p>
+
+  <form action="/account/access-management" method="post">
+    {{ govukRadios({
+      idPrefix: "consent",
+      name: "consent",
+      fieldset: {
+        legend: {
+          text: 'account.pages.accessManagement.consentQuestion' | translate,
+          isPageHeading: true,
+          classes: "govuk-fieldset__legend--l"
+        }
+        },
+        hint: {
+          text: 'account.pages.accessManagement.hint' | translate 
+        },
+        items: [
+          {
+          value: "yes",
+          text: 'account.pages.accessManagement.affirmative' | translate
+          },{
+          value: "no",
+          text: 'account.pages.accessManagement.negative' | translate
+          }
+        ]
+      }) 
+    }}
+
+    <input type="hidden" name="requestVc" value={{requestVc}}>
+    <input type="hidden" name="redirectUrl" value={{redirectUrl}}>
+    <input type="hidden" name="requestVcUrl" value={{requestVcUrl}}>
+    {{ govukButton({
+      text: 'account.pages.accessManagement.buttonText' | translate,
+      type: "submit"
+      }) 
+    }}
+  </form>
+{% endblock %}

--- a/src/views/account/access-management.njk
+++ b/src/views/account/access-management.njk
@@ -8,27 +8,27 @@
 {% block content %}
   <h1 class="govuk-heading-l govuk-!-margin-bottom-7">{{ 'account.pages.accessManagement.title' | translate }}</h1>
 
-  <p>
+  <p class="govuk-body">
     Who's Asking for Permission: {{ credentialSubject["id"]}}
   </p>
 
-  <p>
+  <p class="govuk-body">
     What: {{ credentialSubject["hasConsent"]["mode"] }}
   </p>
 
-  <p>
+  <p class="govuk-body">
     Status: {{ credentialSubject["hasConsent"]["hasStatus"] }}
   </p>
 
-  <p>
+  <p class="govuk-body">
     What: {{ credentialSubject["hasConsent"]["forPersonalData"] }}
   </p>
 
-  <p>
+  <p class="govuk-body">
     For what purpose: {{ credentialSubject["hasConsent"]["forPurpose"] }}
   </p>
 
-  <p>
+  <p class="govuk-body">
     Subject of the request: {{ credentialSubject["hasConsent"]["isConsentForDataSubject"] }}
   </p>
 
@@ -39,7 +39,7 @@
       fieldset: {
         legend: {
           text: 'account.pages.accessManagement.consentQuestion' | translate,
-          isPageHeading: true,
+          isPageHeading: false,
           classes: "govuk-fieldset__legend--l"
         }
         },


### PR DESCRIPTION
This PR adds in the access grant flow for the National Insurance number app. A user can now:

1. Start at `/nino` in the DWP app
2. Enter their NI number
3. Click to save their number
4. The DWP app generates an access request and redirects the user to a new page in the account management app
5. The account management app displays the access request and allows the user to allow or deny it
6. If they accept, they're redirected back to the DWP app with an access grant.
7. The DWP app uses this access grant to write the NI number to their pod

The content and design of some screens here is very much WIP. Follow up PRs can improve these, this one is just about getting the flow working.

We're not writing the binary VC to a user's pod like we were for the identity VCs. This is because the Inrupt library doesn't have a function to write a file to a pod using a VC as the authorisation method. Again, this is something we can add in the future if we need it, but right now this is enough to get things working.

---

_Huw's original draft PR description:_

Ok this is as far as I got.
Nearly done, I think it's close but there's a couple of issues left:

1. See the commit, Typescript does not like [this line](https://github.com/alphagov/di-solid-prototype/pull/135/commits/389df822c4fb540f0b691027ffbd85ce8d6c8e52#diff-36610cad0b3f8dae8097c5dd4c700ad2819aa9a99c7e927dcbcb0fcd67cd356fR174). I cannot for the life of me work out why, what i'm getting back from that function should be good RDF... and I thought the API for this should be the same as the usual solid client 🤔 . This might be a candidate for an Inrupt question if anyone who knows their SDK is around this week?

2. Not clear at all if [its possible to save files](https://github.com/alphagov/di-solid-prototype/pull/135/commits/1e444954f25869a230e3df4f8ccdb364240d537a) with this route... which is very odd? Again might ask inrupt?

9. Unclear if we need this [bearer addition](https://github.com/alphagov/di-solid-prototype/pull/135/commits/4af2da297578e85d4d7637e1df925efa8b80ed02)... I've tested and seems to work with it. But haven't been able to test without it after making a read / write request with the VC 🤔 . Perhaps see if everything is working then toggle this commit.

Hope the steps are otherwise easy to follow, I tried to pack the commits with as much as possible.

Really hoping it's just a case of resolving that issue... then it _should_ write to the pod.

There's some really duff content from me, so it'll need a pass from content / design.
But I tried to leave all the raw data showing in the access controls to give a feel for what we could resolve? (except time... i forgot that bit).

I'd also really like to try that [Multilingual RDF ](https://github.com/alphagov/di-solid-prototype/pull/76) for [purposes](https://github.com/alphagov/di-solid-prototype/pull/135/commits/ddf080b0f9c388187d931962e3d61ff5b1ae5249#diff-36610cad0b3f8dae8097c5dd4c700ad2819aa9a99c7e927dcbcb0fcd67cd356fR46)... happy for that to be a task I pick up when I'm back!

