### PR TITLE
GUA-324: Add logout buttons to the homepage

### DIFF
--- a/src/controllers/login.ts
+++ b/src/controllers/login.ts
@@ -57,3 +57,14 @@ export function clearAppSessionGet(req: Request, res: Response): void {
   }
   res.redirect("/");
 }
+
+export function logoutAuthGet(req: Request, res: Response): void {
+  if (req.session) {
+    req.session = null;
+  }
+  res.redirect("https://oidc.integration.account.gov.uk/logout");
+}
+
+export function logoutESSGet(req: Request, res: Response): void {
+  res.redirect(`${getEssServiceURI(EssServices.OpenId)}/endsession`);
+}

--- a/src/routes/login.ts
+++ b/src/routes/login.ts
@@ -3,6 +3,8 @@ import {
   callbackGet,
   clearAppSessionGet,
   loginGet,
+  logoutAuthGet,
+  logoutESSGet,
 } from "../controllers/login";
 
 const router = express.Router();
@@ -10,5 +12,7 @@ const router = express.Router();
 router.get("/", loginGet);
 router.get("/callback", callbackGet);
 router.get("/clear-session", clearAppSessionGet);
+router.get("/logout-auth", logoutAuthGet);
+router.get("/logout-ess", logoutESSGet);
 
 export default router;

--- a/src/views/index.njk
+++ b/src/views/index.njk
@@ -56,10 +56,25 @@
     <li><a href="/personal-tax/choose-paperless" class="govuk-link">Choose how to get your legal notices, penalty notices and tax letters</a></li>
   </ul>
 
-  <h3 class="govuk-heading-s">Clear app session</h2>
+  <h3 class="govuk-heading-s">Logout</h2>
 
   {{ govukButton({
       text: "Clear app session",
       href: "/login/clear-session"
+  }) }}
+
+  <p class="govuk-body">To log out of the prototype you need to sign out of both Auth and the ESS Broker.</p>
+
+  {{ govukButton({
+      text: "Sign out from Auth (opens in new tab)",
+      href: "/login/logout-auth",
+      attributes: {"target": "_blank"}
+  }) }}
+
+  <p class="govuk-body"></p>
+  {{ govukButton({
+      text: "Sign out from ESS broker (opens in new tab)",
+      href: "/login/logout-ess",
+      attributes: {"target": "_blank"}
   }) }}
 {% endblock %}

--- a/src/views/index.njk
+++ b/src/views/index.njk
@@ -64,17 +64,19 @@
   }) }}
 
   <p class="govuk-body">To log out of the prototype you need to sign out of both Auth and the ESS Broker.</p>
-
+  <div>
   {{ govukButton({
       text: "Sign out from Auth (opens in new tab)",
       href: "/login/logout-auth",
       attributes: {"target": "_blank"}
   }) }}
+  </div>
 
-  <p class="govuk-body"></p>
+  <div>
   {{ govukButton({
       text: "Sign out from ESS broker (opens in new tab)",
       href: "/login/logout-ess",
       attributes: {"target": "_blank"}
   }) }}
+  </div>
 {% endblock %}


### PR DESCRIPTION
This is a bit of a hack because users of the PoC app are logged in to
two separate external services - DI's Auth and the ESS broker.

Both support OIDC standards compliant logout, but it'll be a bit
complicated to set up and we'd need to get someone on Auth or DfA to
add a logout redirect URL to the client registry for us.

Instead, simply add two buttons on the homepage which each log the
user out of one external service.