### PR TITLE
Correct 'HMRC' to 'DWP' in stretch goal diagram

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -83,7 +83,7 @@ graph TD
     Q[Save your NI number?] -->|Request to write NI number|L
     L -->|Ok|Q
     Q -->|Redirect to|R
-    R[Can HMRC write to your account?] -->|Approve|S
+    R[Can DWP write to your account?] -->|Approve|S
     S((NI checker)) -->|Save NI number| T
     T[(User's pod)] -->|Ok| S
     S -->|Return to|U


### PR DESCRIPTION
I think this is correct, but it's possible I've misunderstood the diagram.

The fictional NINO checker service would be run
by DWP in real life. So it would be DWP writing
this data to the Pod.

By coincidence, this would also make the diagram easier to follow, as would become easier to distinguish the two services involved (PTA = HMRC; NINO checker = DWP)